### PR TITLE
FEAT: api 연동 세팅 작업

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react-diff-viewer-continued": "^3.4.0",
         "react-dom": "^18.2.0",
         "react-icons": "^4.11.0",
+        "react-query": "^3.39.3",
         "react-router-dom": "^6.21.2",
         "react-slick": "^0.30.3",
         "react-tooltip": "^5.28.1",
@@ -2477,8 +2478,16 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -2514,6 +2523,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/broadcast-channel": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
+      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "detect-node": "^2.1.0",
+        "js-sha3": "0.8.0",
+        "microseconds": "0.2.0",
+        "nano-time": "1.0.0",
+        "oblivious-set": "1.0.0",
+        "rimraf": "3.0.2",
+        "unload": "2.2.0"
       }
     },
     "node_modules/browserslist": {
@@ -2767,7 +2792,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/convert-source-map": {
@@ -3101,6 +3125,12 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "license": "MIT"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -3984,6 +4014,12 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4318,6 +4354,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "node_modules/inherits": {
@@ -4833,6 +4880,12 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5057,6 +5110,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/match-sorter": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.4.tgz",
+      "integrity": "sha512-jfZW7cWS5y/1xswZo8VBOdudUiSd9nifYRWphc9M5D/ee4w4AoXLgBEdRbgVaxbMuagBPeUC5y2Hi8DO6o9aDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.8",
+        "remove-accents": "0.5.0"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5095,6 +5158,12 @@
       "engines": {
         "node": ">=8.6"
       }
+    },
+    "node_modules/microseconds": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
+      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==",
+      "license": "MIT"
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
@@ -5159,6 +5228,15 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nano-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
+      "license": "ISC",
+      "dependencies": {
+        "big-integer": "^1.6.16"
       }
     },
     "node_modules/nanoid": {
@@ -5331,6 +5409,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oblivious-set": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
+      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==",
+      "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5450,6 +5543,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -5876,6 +5978,32 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/react-query": {
+      "version": "3.39.3",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.3.tgz",
+      "integrity": "sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "broadcast-channel": "^3.4.1",
+        "match-sorter": "^6.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -6100,6 +6228,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/remove-accents": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
+      "license": "MIT"
+    },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
@@ -6142,6 +6276,65 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/rollup": {
@@ -7124,6 +7317,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unload": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
+      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.6.2",
+        "detect-node": "^2.0.4"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -7577,6 +7780,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "codify-frontend",
       "version": "0.0.0",
       "dependencies": {
-        "axios": "^1.9.0",
+        "axios": "^1.11.0",
         "jszip": "^3.10.1",
         "react": "^18.2.0",
         "react-datepicker": "^8.3.0",
@@ -2428,13 +2428,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "axios": "^1.9.0",
+    "axios": "^1.11.0",
     "jszip": "^3.10.1",
     "react": "^18.2.0",
     "react-datepicker": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-diff-viewer-continued": "^3.4.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.11.0",
+    "react-query": "^3.39.3",
     "react-router-dom": "^6.21.2",
     "react-slick": "^0.30.3",
     "react-tooltip": "^5.28.1",

--- a/src/features/Assignment/SubjectSelectpage.tsx
+++ b/src/features/Assignment/SubjectSelectpage.tsx
@@ -51,14 +51,20 @@ const SubjectSelectPage: React.FC = () => {
       addSubject(
         { subjectName: trimmedName },
         {
-          onSuccess: () => {
-            const newSubject = {
-              name: trimmedName,
-              code: `SUBJ-${Date.now()}`,
-            };
-            setSelectedSubject(newSubject);
-            queryClient.invalidateQueries(['subjects']);
-            navigate('/assignment/name');
+          onSuccess: (data) => {
+            if (data.isSuccess && data.result) {
+              const { subjectId } = data.result;
+
+              setSelectedSubject({
+                name: trimmedName,
+                code: subjectId.toString(),
+              });
+
+              queryClient.invalidateQueries(['subjects']);
+              navigate('/assignment/name');
+            } else {
+              alert('과목 추가 응답이 올바르지 않습니다.');
+            }
           },
           onError: () => {
             alert('과목 추가에 실패했습니다.');

--- a/src/features/Assignment/SubjectSelectpage.tsx
+++ b/src/features/Assignment/SubjectSelectpage.tsx
@@ -5,42 +5,39 @@ import Button from '@components/Button';
 import { useNavigate } from 'react-router-dom';
 import { FiArrowRight, FiSearch } from 'react-icons/fi';
 import { useSubjectStore } from '@stores/useSubjectStore';
-
-const dummySubjects = [
-  { name: '자료구조', code: 'CS101' },
-  { name: '운영체제', code: 'CS102' },
-  { name: '알고리즘', code: 'CS103' },
-  { name: '캡스톤디자인', code: 'CS401' },
-  { name: '인공지능', code: 'CS201' },
-  { name: '컴퓨터비전', code: 'CS202' },
-  { name: '딥러닝', code: 'CS203' },
-  { name: '블록체인', code: 'CS204' },
-  { name: '컴파일러', code: 'CS205' },
-  { name: '컴퓨터네트워크', code: 'CS206' },
-  { name: '웹프로그래밍', code: 'CS207' },
-];
+import { useQueryClient } from 'react-query';
+import { useSubjects } from '@hooks/useSubjects';
+import { useAddSubject } from '@hooks/useAddSubject';
+import { useAccessToken } from '@hooks/useAccessToken';
 
 const SubjectSelectPage: React.FC = () => {
   const [newSubjectName, setNewSubjectName] = useState('');
-  const [selectedCode, setSelectedCode] = useState<string | null>(null);
+  const [selectedName, setSelectedName] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
-  const navigate = useNavigate();
   const { setSelectedSubject } = useSubjectStore();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
-  const filteredSubjects = dummySubjects.filter((subject) =>
-    subject.name.toLowerCase().includes(searchTerm.toLowerCase())
+  const token = useAccessToken();
+  const { data: subjectData, isLoading } = useSubjects(token);
+  const { mutate: addSubject, isLoading: isAdding } = useAddSubject(token);
+
+  const subjects = subjectData?.result ?? [];
+
+  const filteredSubjects = subjects.filter((name) =>
+    name.toLowerCase().includes(searchTerm.toLowerCase())
   );
 
-  const handleSelect = (subject: (typeof dummySubjects)[number]) => {
-    if (selectedCode === subject.code) {
+  const handleSelect = (name: string) => {
+    if (selectedName === name) {
       // 이미 선택된 항목을 다시 클릭한 경우 선택 해제
-      setSelectedCode(null);
+      setSelectedName(null);
       setNewSubjectName('');
       setSelectedSubject(null);
     } else {
-      setSelectedCode(subject.code);
-      setNewSubjectName(subject.name);
-      setSelectedSubject(subject);
+      setSelectedName(name);
+      setNewSubjectName(name);
+      setSelectedSubject({ name, code: name });
     }
   };
 
@@ -48,15 +45,26 @@ const SubjectSelectPage: React.FC = () => {
     const trimmedName = newSubjectName.trim();
     if (!trimmedName) return;
 
-    if (selectedCode) {
+    if (selectedName) {
       navigate('/assignment/name');
     } else {
-      const newSubject = {
-        name: trimmedName,
-        code: `SUBJ-${Date.now()}`,
-      };
-      setSelectedSubject(newSubject);
-      navigate('/assignment/name');
+      addSubject(
+        { subjectName: trimmedName },
+        {
+          onSuccess: () => {
+            const newSubject = {
+              name: trimmedName,
+              code: `SUBJ-${Date.now()}`,
+            };
+            setSelectedSubject(newSubject);
+            queryClient.invalidateQueries(['subjects']);
+            navigate('/assignment/name');
+          },
+          onError: () => {
+            alert('과목 추가에 실패했습니다.');
+          },
+        }
+      );
     }
   };
 
@@ -108,18 +116,22 @@ const SubjectSelectPage: React.FC = () => {
             {/* 과목 리스트 (가로 스크롤) */}
             <div className="w-full max-w-3xl overflow-x-auto pt-1">
               <div className="flex gap-3 min-w-max pr-4 pb-2">
-                {filteredSubjects.length > 0 ? (
-                  filteredSubjects.map((subject) => (
+                {isLoading ? (
+                  <Text variant="caption" color="gray">
+                    불러오는 중...
+                  </Text>
+                ) : filteredSubjects.length > 0 ? (
+                  filteredSubjects.map((name) => (
                     <button
-                      key={subject.code}
-                      onClick={() => handleSelect(subject)}
+                      key={name}
+                      onClick={() => handleSelect(name)}
                       className={`px-4 py-2 rounded-full border whitespace-nowrap transition ${
-                        selectedCode === subject.code
+                        selectedName === name
                           ? 'bg-blue-500 text-white border-blue-500'
                           : 'border-gray-300 text-gray-700 hover:border-blue-300'
                       }`}
                     >
-                      {subject.name}
+                      {name}
                     </button>
                   ))
                 ) : (
@@ -142,7 +154,7 @@ const SubjectSelectPage: React.FC = () => {
               value={newSubjectName}
               onChange={(e) => {
                 setNewSubjectName(e.target.value);
-                setSelectedCode(null); // 기존 선택 해제
+                setSelectedName(null); // 기존 선택 해제
               }}
               className="w-full py-3 px-4 border-b border-gray-300 text-xl focus:outline-none placeholder:text-gray-400"
             />
@@ -156,7 +168,7 @@ const SubjectSelectPage: React.FC = () => {
             variant="primary"
             size="large"
             onClick={handleNext}
-            disabled={!isValid}
+            disabled={!isValid || isAdding}
             iconPosition="right"
             icon={<FiArrowRight size={20} />}
           />

--- a/src/hooks/useAccessToken.ts
+++ b/src/hooks/useAccessToken.ts
@@ -1,0 +1,3 @@
+export const useAccessToken = () => {
+  return localStorage.getItem('accessToken') ?? '';
+};

--- a/src/hooks/useAccessToken.ts
+++ b/src/hooks/useAccessToken.ts
@@ -1,3 +1,17 @@
-export const useAccessToken = () => {
-  return localStorage.getItem('accessToken') ?? '';
+import { useEffect, useState } from 'react';
+
+export const useAccessToken = (): string => {
+  const [token, setToken] = useState<string>('');
+
+  useEffect(() => {
+    try {
+      const accessToken = localStorage.getItem('accessToken') ?? '';
+      setToken(accessToken);
+    } catch (error) {
+      console.warn('localStorage access failed:', error);
+      setToken('');
+    }
+  }, []);
+
+  return token;
 };

--- a/src/hooks/useAccumulatedTopology.ts
+++ b/src/hooks/useAccumulatedTopology.ts
@@ -1,0 +1,15 @@
+import { fetchAccumulatedTopology } from '@services/dashboard';
+import { useQuery } from 'react-query';
+import { AccumulatedApiResponse } from 'types/dashboard';
+
+export const useAccumulatedTopology = (
+  assignmentName: string,
+  token: string
+) => {
+  return useQuery<AccumulatedApiResponse>({
+    queryKey: ['accumulatedTopology', assignmentName],
+    queryFn: () => fetchAccumulatedTopology(assignmentName, token),
+    enabled: !!assignmentName && !!token,
+    staleTime: 1000 * 60 * 5,
+  });
+};

--- a/src/hooks/useAddAssignment.ts
+++ b/src/hooks/useAddAssignment.ts
@@ -1,0 +1,9 @@
+import { addAssignment, addAssignmentRequest } from '@services/submit';
+import { useMutation } from 'react-query';
+import { addAssignmentApiResponse } from 'types/submit';
+
+export const useAddAssignment = (token: string) => {
+  return useMutation<addAssignmentApiResponse, Error, addAssignmentRequest>({
+    mutationFn: (params) => addAssignment(params, token),
+  });
+};

--- a/src/hooks/useAddSubject.ts
+++ b/src/hooks/useAddSubject.ts
@@ -1,0 +1,9 @@
+import { addSubject, addSubjectRequest } from '@services/submit';
+import { useMutation } from 'react-query';
+import { addSubjectApiResponse } from 'types/submit';
+
+export const useAddSubject = (token: string) => {
+  return useMutation<addSubjectApiResponse, Error, addSubjectRequest>({
+    mutationFn: (params) => addSubject(params, token),
+  });
+};

--- a/src/hooks/useAddWeek.ts
+++ b/src/hooks/useAddWeek.ts
@@ -1,0 +1,9 @@
+import { addWeek, addWeekRequest } from '@services/submit';
+import { useMutation } from 'react-query';
+import { addWeekApiResponse } from 'types/submit';
+
+export const useAddWeek = (token: string) => {
+  return useMutation<addWeekApiResponse, Error, addWeekRequest>({
+    mutationFn: (params) => addWeek(params, token),
+  });
+};

--- a/src/hooks/useCompareCode.ts
+++ b/src/hooks/useCompareCode.ts
@@ -1,0 +1,12 @@
+import { compareRequest, fetchCompare } from '@services/result';
+import { useQuery } from 'react-query';
+import { compareApiResponse } from 'types/result';
+
+export const useCompareCode = (params: compareRequest, token: string) => {
+  return useQuery<compareApiResponse>({
+    queryKey: ['compareCode', params.student1, params.student2],
+    queryFn: () => fetchCompare(params, token),
+    enabled: !!token && !!params.student1 && !!params.student2,
+    staleTime: 1000 * 60 * 5,
+  });
+};

--- a/src/hooks/useMainDashboard.ts
+++ b/src/hooks/useMainDashboard.ts
@@ -1,0 +1,12 @@
+import { fetchMain } from '@services/dashboard';
+import { useQuery } from 'react-query';
+import { MainApiResponse } from 'types/dashboard';
+
+export const useMainDashboard = (token: string) => {
+  return useQuery<MainApiResponse>({
+    queryKey: ['mainDashboard'],
+    queryFn: () => fetchMain(token),
+    enabled: !!token,
+    staleTime: 1000 * 60 * 10,
+  });
+};

--- a/src/hooks/usePlagiarismJudge.ts
+++ b/src/hooks/usePlagiarismJudge.ts
@@ -1,0 +1,12 @@
+import { compareRequest, fetchJudge } from '@services/result';
+import { useQuery } from 'react-query';
+import { judgeApiResponse } from 'types/result';
+
+export const usePlagiarismJudge = (params: compareRequest, token: string) => {
+  return useQuery<judgeApiResponse>({
+    queryKey: ['plagiarismJudge', params.student1, params.student2],
+    queryFn: () => fetchJudge(params, token),
+    enabled: !!token && !!params.student1 && !!params.student2,
+    staleTime: 1000 * 60 * 5,
+  });
+};

--- a/src/hooks/usePresignedUrl.ts
+++ b/src/hooks/usePresignedUrl.ts
@@ -1,0 +1,12 @@
+import {
+  getPresignedUrl,
+  PresignedUrlRequest,
+  PresignedUrlResponse,
+} from '@services/submit';
+import { useMutation } from 'react-query';
+
+export const usePresignedUrl = (token: string) => {
+  return useMutation<PresignedUrlResponse, Error, PresignedUrlRequest>({
+    mutationFn: (params) => getPresignedUrl(params, token),
+  });
+};

--- a/src/hooks/useRecord.ts
+++ b/src/hooks/useRecord.ts
@@ -4,7 +4,7 @@ import { RecordApiResponse } from 'types/dashboard';
 
 export const useRecord = (token: string) => {
   return useQuery<RecordApiResponse>({
-    queryKey: ['record'],
+    queryKey: ['record', token],
     queryFn: () => fetchRecord(token),
     enabled: !!token,
     staleTime: 1000 * 60 * 5,

--- a/src/hooks/useRecord.ts
+++ b/src/hooks/useRecord.ts
@@ -1,0 +1,12 @@
+import { fetchRecord } from '@services/dashboard';
+import { useQuery } from 'react-query';
+import { RecordApiResponse } from 'types/dashboard';
+
+export const useRecord = (token: string) => {
+  return useQuery<RecordApiResponse>({
+    queryKey: ['record'],
+    queryFn: () => fetchRecord(token),
+    enabled: !!token,
+    staleTime: 1000 * 60 * 5,
+  });
+};

--- a/src/hooks/useSaveResult.ts
+++ b/src/hooks/useSaveResult.ts
@@ -1,0 +1,9 @@
+import { save, saveRequest } from '@services/result';
+import { useMutation } from 'react-query';
+import { saveApiResponse } from 'types/result';
+
+export const useSaveResult = (token: string) => {
+  return useMutation<saveApiResponse, Error, saveRequest>({
+    mutationFn: (params) => save(params, token),
+  });
+};

--- a/src/hooks/useSimilarityGraph.ts
+++ b/src/hooks/useSimilarityGraph.ts
@@ -1,0 +1,15 @@
+import { fetchGraph, fetchGraphRequest } from '@services/result';
+import { useQuery } from 'react-query';
+import { graphApiResponse } from 'types/result';
+
+export const useSimilarityGraph = (
+  params: fetchGraphRequest,
+  token: string
+) => {
+  return useQuery<graphApiResponse>({
+    queryKey: ['similarityGraph', params.assignmentId, params.weekTitle],
+    queryFn: () => fetchGraph(params, token),
+    enabled: !!token && !!params.assignmentId && !!params.weekTitle,
+    staleTime: 1000 * 60 * 5,
+  });
+};

--- a/src/hooks/useSimilarityTopology.ts
+++ b/src/hooks/useSimilarityTopology.ts
@@ -1,0 +1,15 @@
+import { fetchGraphRequest, fetchTopology } from '@services/result';
+import { useQuery } from 'react-query';
+import { topologyApiResponse } from 'types/result';
+
+export const useSimilarityTopology = (
+  params: fetchGraphRequest,
+  token: string
+) => {
+  return useQuery<topologyApiResponse>({
+    queryKey: ['similarityTopology', params.assignmentId, params.weekTitle],
+    queryFn: () => fetchTopology(params, token),
+    enabled: !!token && !!params.assignmentId && !!params.weekTitle,
+    staleTime: 1000 * 60 * 5,
+  });
+};

--- a/src/hooks/useStartAnalysis.ts
+++ b/src/hooks/useStartAnalysis.ts
@@ -1,0 +1,9 @@
+import { fetchAnalyze } from '@services/submit';
+import { useMutation } from 'react-query';
+import { analyzeApiResponse } from 'types/submit';
+
+export const useStartAnalysis = (token: string) => {
+  return useMutation<analyzeApiResponse, Error, void>({
+    mutationFn: () => fetchAnalyze(token),
+  });
+};

--- a/src/hooks/useSubjects.ts
+++ b/src/hooks/useSubjects.ts
@@ -1,0 +1,12 @@
+import { fetchSubject } from '@services/submit';
+import { useQuery } from 'react-query';
+import { viewSubjectApiResponse } from 'types/submit';
+
+export const useSubjects = (token: string) => {
+  return useQuery<viewSubjectApiResponse>({
+    queryKey: ['subjects'],
+    queryFn: () => fetchSubject(token),
+    enabled: !!token,
+    staleTime: 1000 * 60 * 5,
+  });
+};

--- a/src/hooks/useUploadMetadata.ts
+++ b/src/hooks/useUploadMetadata.ts
@@ -1,0 +1,9 @@
+import { submitUploadMetadata, UploadMetadataRequest } from '@services/submit';
+import { useMutation } from 'react-query';
+import { uploadApiResponse } from 'types/submit';
+
+export const useUploadMetadata = (token: string) => {
+  return useMutation<uploadApiResponse, Error, UploadMetadataRequest>({
+    mutationFn: (params) => submitUploadMetadata(params, token),
+  });
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,18 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+if (import.meta.env.VITE_USE_MOCK === 'true') {
+  localStorage.setItem('accessToken', 'mock-token');
+}
+
+const queryClient = new QueryClient();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </StrictMode>
 );

--- a/src/mocks/accumulatedMock.ts
+++ b/src/mocks/accumulatedMock.ts
@@ -1,0 +1,31 @@
+import { AccumulatedApiResponse } from 'types/dashboard';
+
+export const accumulatedMock: AccumulatedApiResponse = {
+  status: 200,
+  success: true,
+  message: {
+    nodes: [
+      { id: '21000000', label: 'Student A' },
+      { id: '21000001', label: 'Student B' },
+      { id: '21000002', label: 'Student C' },
+    ],
+    edges: [
+      {
+        id: '21000000-21000001',
+        from: '21000000',
+        to: '21000001',
+        count: 3,
+        value: 0.85,
+        width: 8.5,
+      },
+      {
+        id: '21000001-21000002',
+        from: '21000001',
+        to: '21000002',
+        count: 2,
+        value: 0.6,
+        width: 6.0,
+      },
+    ],
+  },
+};

--- a/src/mocks/addAssignmentMock.ts
+++ b/src/mocks/addAssignmentMock.ts
@@ -1,0 +1,11 @@
+import { addAssignmentApiResponse } from 'types/submit';
+
+export const addAssignmentMock: addAssignmentApiResponse = {
+  isSuccess: true,
+  code: 'COMMON200',
+  message: '요청에 성공했습니다.',
+  result: {
+    assignmentId: 1,
+    message: '과제가 성공적으로 생성되었습니다.',
+  },
+};

--- a/src/mocks/addSubjectMock.ts
+++ b/src/mocks/addSubjectMock.ts
@@ -1,0 +1,11 @@
+import { addSubjectApiResponse } from 'types/submit';
+
+export const addSubjectMock: addSubjectApiResponse = {
+  isSuccess: true,
+  code: 'COMMON200',
+  message: '요청에 성공했습니다.',
+  result: {
+    subjectId: 1,
+    message: '과제가 성공적으로 생성되었습니다.',
+  },
+};

--- a/src/mocks/addWeekMock.ts
+++ b/src/mocks/addWeekMock.ts
@@ -1,0 +1,10 @@
+import { addWeekApiResponse } from 'types/submit';
+
+export const addWeekMock: addWeekApiResponse = {
+  isSuccess: true,
+  code: 'COMMON200',
+  message: '요청에 성공했습니다.',
+  result: {
+    message: '주차가 성공적으로 생성되었습니다.',
+  },
+};

--- a/src/mocks/analyzeMock.ts
+++ b/src/mocks/analyzeMock.ts
@@ -1,0 +1,9 @@
+import { analyzeApiResponse } from 'types/submit';
+
+export const analyzeMock: analyzeApiResponse = {
+  status: 200,
+  success: true,
+  message: {
+    status: 'DONE',
+  },
+};

--- a/src/mocks/compareMock.ts
+++ b/src/mocks/compareMock.ts
@@ -1,0 +1,40 @@
+import { compareApiResponse } from 'types/result';
+
+export const compareMock: compareApiResponse = {
+  status: 200,
+  success: true,
+  message: {
+    student1: {
+      id: '21000000',
+      name: 'Student A',
+      fileName: 'file_name1.py',
+      submissionTime: '2025-03-29 17:05',
+      code: {
+        code: [
+          'int main() {',
+          '  int a = 10;',
+          '  int b = 20;',
+          '  return a + b;',
+          '}',
+        ],
+        lines: [2, 3],
+      },
+    },
+    student2: {
+      id: '21000001',
+      name: 'Student B',
+      fileName: 'file_name2.py',
+      submissionTime: '2025-03-29 19:05',
+      code: {
+        code: [
+          'int main() {',
+          '  int a = 10;',
+          '  int b = 20;',
+          '  return a + b;',
+          '}',
+        ],
+        lines: [2, 3],
+      },
+    },
+  },
+};

--- a/src/mocks/graphMock.ts
+++ b/src/mocks/graphMock.ts
@@ -1,0 +1,35 @@
+import { graphApiResponse } from 'types/result';
+
+export const graphMock: graphApiResponse = {
+  status: 200,
+  success: true,
+  message: {
+    nodes: [
+      { id: '21000000', label: 'Student A' },
+      { id: '21000001', label: 'Student B' },
+      { id: '21000002', label: 'Student C' },
+    ],
+    filterSummary: {
+      total: 3,
+      aboveThreshold: 2,
+      belowThreshold: 1,
+      threshold: 0.7,
+    },
+    filteredPairs: {
+      aboveThreshold: [
+        {
+          from: '21000000',
+          to: '21000001',
+          similarity: 0.88,
+        },
+      ],
+      belowThreshold: [
+        {
+          from: '21000001',
+          to: '21000002',
+          similarity: 0.6,
+        },
+      ],
+    },
+  },
+};

--- a/src/mocks/judgeMock.ts
+++ b/src/mocks/judgeMock.ts
@@ -1,0 +1,19 @@
+import { judgeApiResponse } from 'types/result';
+
+export const judgeMock: judgeApiResponse = {
+  status: 200,
+  success: true,
+  message: {
+    similarity: 95,
+    student1: {
+      id: '21000000',
+      name: 'Student A',
+      submittedTime: '2025-03-29 17:06',
+    },
+    student2: {
+      id: '21000001',
+      name: 'Student B',
+      submittedTime: '2025-03-30 17:06',
+    },
+  },
+};

--- a/src/mocks/mainMock.ts
+++ b/src/mocks/mainMock.ts
@@ -1,0 +1,23 @@
+import { MainApiResponse } from 'types/dashboard';
+
+export const mainMock: MainApiResponse = {
+  status: 200,
+  success: true,
+  message: {
+    user: {
+      userId: 123,
+      userName: '사용자',
+    },
+    testCount: 5,
+    subjects: [
+      {
+        subjectId: 1,
+        subjectName: '프로그래밍 입문',
+      },
+      {
+        subjectId: 2,
+        subjectName: '공학 수학',
+      },
+    ],
+  },
+};

--- a/src/mocks/recordMock.ts
+++ b/src/mocks/recordMock.ts
@@ -1,0 +1,73 @@
+import { RecordApiResponse } from 'types/dashboard';
+
+export const recordMock: RecordApiResponse = {
+  status: 200,
+  success: true,
+  message: {
+    nodes: [
+      { id: '21000000', label: 'Student A', submittedAt: '2025-04-11 14:00' },
+      { id: '21000001', label: 'Student B', submittedAt: '2025-04-11 15:00' },
+      { id: '21000002', label: 'Student C', submittedAt: '2025-04-11 15:00' },
+    ],
+    edges: [
+      {
+        week: 1,
+        weekData: [
+          {
+            id: '21000000-21000001',
+            from: '21000000',
+            to: '21000001',
+            value: 0.85,
+            width: 8.5,
+            histories: [
+              {
+                submittedFrom: '2025-04-11 14:00',
+                submittedTo: '2025-04-11 15:00',
+                similarity: 0.88,
+              },
+              {
+                submittedFrom: '2025-04-18 13:40',
+                submittedTo: '2025-04-18 13:45',
+                similarity: 0.83,
+              },
+              {
+                submittedFrom: '2025-04-25 12:30',
+                submittedTo: '2025-04-25 12:31',
+                similarity: 0.84,
+              },
+            ],
+          },
+        ],
+      },
+      {
+        week: 2,
+        weekData: [
+          {
+            id: '21000000-21000001',
+            from: '21000000',
+            to: '21000001',
+            value: 0.85,
+            width: 8.5,
+            histories: [
+              {
+                submittedFrom: '2025-04-11 14:00',
+                submittedTo: '2025-04-11 15:00',
+                similarity: 0.88,
+              },
+              {
+                submittedFrom: '2025-04-18 13:40',
+                submittedTo: '2025-04-18 13:45',
+                similarity: 0.83,
+              },
+              {
+                submittedFrom: '2025-04-25 12:30',
+                submittedTo: '2025-04-25 12:31',
+                similarity: 0.84,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+};

--- a/src/mocks/saveMock.ts
+++ b/src/mocks/saveMock.ts
@@ -1,0 +1,6 @@
+import { saveApiResponse } from 'types/result';
+
+export const saveMock: saveApiResponse = {
+  status: 200,
+  success: true,
+};

--- a/src/mocks/topologyMock.ts
+++ b/src/mocks/topologyMock.ts
@@ -8,7 +8,7 @@ export const topologyMock: topologyApiResponse = {
       {
         id: '21000000',
         label: '학생 1',
-        fildeName: '학생1.cpp',
+        fileName: '학생1.cpp',
         submittedAt: '2025-03-29 17:10',
         relatedFiles: [
           {
@@ -24,7 +24,7 @@ export const topologyMock: topologyApiResponse = {
       {
         id: '21000001',
         label: '학생2',
-        fildeName: '학생2.cpp',
+        fileName: '학생2.cpp',
         submittedAt: '2025-03-29 17:11',
         relatedFiles: [
           {
@@ -40,7 +40,7 @@ export const topologyMock: topologyApiResponse = {
       {
         id: '21000002',
         label: '학생3',
-        fildeName: '학생3.cpp',
+        fileName: '학생3.cpp',
         submittedAt: '2025-03-29 17:12',
         relatedFiles: [
           {

--- a/src/mocks/topologyMock.ts
+++ b/src/mocks/topologyMock.ts
@@ -1,0 +1,88 @@
+import { topologyApiResponse } from 'types/result';
+
+export const topologyMock: topologyApiResponse = {
+  status: 200,
+  success: true,
+  message: {
+    nodes: [
+      {
+        id: '21000000',
+        label: '학생 1',
+        fildeName: '학생1.cpp',
+        submittedAt: '2025-03-29 17:10',
+        relatedFiles: [
+          {
+            fileName: '학생2.cpp',
+            similarity: 0.92,
+          },
+          {
+            fileName: '학생3.cpp',
+            similarity: 0.87,
+          },
+        ],
+      },
+      {
+        id: '21000001',
+        label: '학생2',
+        fildeName: '학생2.cpp',
+        submittedAt: '2025-03-29 17:11',
+        relatedFiles: [
+          {
+            fileName: '학생1.cpp',
+            similarity: 0.92,
+          },
+          {
+            fileName: '학생3.cpp',
+            similarity: 0.75,
+          },
+        ],
+      },
+      {
+        id: '21000002',
+        label: '학생3',
+        fildeName: '학생3.cpp',
+        submittedAt: '2025-03-29 17:12',
+        relatedFiles: [
+          {
+            fileName: '학생1.cpp',
+            similarity: 0.92,
+          },
+          {
+            fileName: '학생2.cpp',
+            similarity: 0.75,
+          },
+        ],
+      },
+    ],
+    edges: [
+      {
+        id: '21000000-21000001',
+        from: '21000000',
+        to: '21000001',
+        value: 0.92,
+        width: 9.2,
+        comparedFiles: '학생1.cpp - 학생2.cpp',
+        histories: [
+          {
+            submittedFrom: '2025-03-29 17:10',
+            submittedTo: '2025-03-29 17:11',
+          },
+        ],
+      },
+      {
+        id: '21000001-21000002',
+        from: '21000001',
+        to: '21000002',
+        value: 0.75,
+        width: 7.5,
+        comparedFiles: '학생2.cpp - 학생3.cpp',
+        histories: [
+          {
+            submittedFrom: '2025-03-29 17:11',
+            submittedTo: '2025-03-29 17:12',
+          },
+        ],
+      },
+    ],
+  },
+};

--- a/src/mocks/uploadMock.ts
+++ b/src/mocks/uploadMock.ts
@@ -1,0 +1,10 @@
+import { uploadApiResponse } from 'types/submit';
+
+export const uploadMock: uploadApiResponse = {
+  isSuccess: true,
+  code: 'COMMON200',
+  message: '요청에 성공했습니다.',
+  result: {
+    message: '파일이 성공적으로 업로드되었습니다.',
+  },
+};

--- a/src/mocks/viewSubjectMock.ts
+++ b/src/mocks/viewSubjectMock.ts
@@ -1,0 +1,8 @@
+import { viewSubjectApiResponse } from 'types/submit';
+
+export const viewSubjectMock: viewSubjectApiResponse = {
+  isSuccess: true,
+  code: 'COMMON200',
+  message: '과목 목록 조회 성공',
+  result: ['운영체제', '알고리즘', '캡스톤디자인', '인공지능'],
+};

--- a/src/services/axiosInstance.ts
+++ b/src/services/axiosInstance.ts
@@ -1,0 +1,10 @@
+import axios from 'axios';
+
+const axiosInstance = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+export default axiosInstance;

--- a/src/services/dashboard.ts
+++ b/src/services/dashboard.ts
@@ -4,13 +4,21 @@ import {
   RecordApiResponse,
 } from 'types/dashboard';
 import axiosInstance from './axiosInstance';
+import { accumulatedMock } from 'mocks/accumulatedMock';
+import { recordMock } from 'mocks/recordMock';
+import { mainMock } from 'mocks/mainMock';
 
 /// 누적 네트워크 토폴로지
 
 export const fetchAccumulatedTopology = async (
   assignmentName: string,
   token: string
-) => {
+): Promise<AccumulatedApiResponse> => {
+  if (import.meta.env.VITE_USE_MOCK === 'true') {
+    await new Promise((r) => setTimeout(r, 300));
+    return accumulatedMock;
+  }
+
   const response = await axiosInstance.get<AccumulatedApiResponse>(
     `/api/dashboard/accumulate`,
     {
@@ -23,7 +31,14 @@ export const fetchAccumulatedTopology = async (
 
 /// 저장된 분석 기록
 
-export const fetchRecord = async (token: string) => {
+export const fetchRecord = async (
+  token: string
+): Promise<RecordApiResponse> => {
+  if (import.meta.env.VITE_USE_MOCK === 'true') {
+    await new Promise((r) => setTimeout(r, 300));
+    return recordMock;
+  }
+
   const response = await axiosInstance.get<RecordApiResponse>(
     `api/dashboard/record`,
     {
@@ -35,7 +50,12 @@ export const fetchRecord = async (token: string) => {
 
 /// 대시보드 메인
 
-export const fetchMain = async (token: string) => {
+export const fetchMain = async (token: string): Promise<MainApiResponse> => {
+  if (import.meta.env.VITE_USE_MOCK === 'true') {
+    await new Promise((r) => setTimeout(r, 300));
+    return mainMock;
+  }
+
   const response = await axiosInstance.get<MainApiResponse>(
     `api/dashboard/main`,
     {

--- a/src/services/dashboard.ts
+++ b/src/services/dashboard.ts
@@ -40,7 +40,7 @@ export const fetchRecord = async (
   }
 
   const response = await axiosInstance.get<RecordApiResponse>(
-    `api/dashboard/record`,
+    `/api/dashboard/record`,
     {
       headers: { Authorization: `Bearer ${token}` },
     }
@@ -57,7 +57,7 @@ export const fetchMain = async (token: string): Promise<MainApiResponse> => {
   }
 
   const response = await axiosInstance.get<MainApiResponse>(
-    `api/dashboard/main`,
+    `/api/dashboard/main`,
     {
       headers: { Authorization: `Bearer ${token}` },
     }

--- a/src/services/dashboard.ts
+++ b/src/services/dashboard.ts
@@ -4,9 +4,9 @@ import {
   RecordApiResponse,
 } from 'types/dashboard';
 import axiosInstance from './axiosInstance';
-import { accumulatedMock } from 'mocks/accumulatedMock';
-import { recordMock } from 'mocks/recordMock';
-import { mainMock } from 'mocks/mainMock';
+import { accumulatedMock } from '@mocks/accumulatedMock';
+import { recordMock } from '@mocks/recordMock';
+import { mainMock } from '@mocks/mainMock';
 
 /// 누적 네트워크 토폴로지
 

--- a/src/services/dashboard.ts
+++ b/src/services/dashboard.ts
@@ -1,0 +1,46 @@
+import {
+  AccumulatedApiResponse,
+  MainApiResponse,
+  RecordApiResponse,
+} from 'types/dashboard';
+import axiosInstance from './axiosInstance';
+
+/// 누적 네트워크 토폴로지
+
+export const fetchAccumulatedTopology = async (
+  assignmentName: string,
+  token: string
+) => {
+  const response = await axiosInstance.get<AccumulatedApiResponse>(
+    `/api/dashboard/accumulate`,
+    {
+      params: { assignmentName },
+      headers: { Authorization: `Bearer ${token}` },
+    }
+  );
+  return response.data;
+};
+
+/// 저장된 분석 기록
+
+export const fetchRecord = async (token: string) => {
+  const response = await axiosInstance.get<RecordApiResponse>(
+    `api/dashboard/record`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+    }
+  );
+  return response.data;
+};
+
+/// 대시보드 메인
+
+export const fetchMain = async (token: string) => {
+  const response = await axiosInstance.get<MainApiResponse>(
+    `api/dashboard/main`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+    }
+  );
+  return response.data;
+};

--- a/src/services/result.ts
+++ b/src/services/result.ts
@@ -1,0 +1,117 @@
+import {
+  compareApiResponse,
+  graphApiResponse,
+  judgeApiResponse,
+  saveApiResponse,
+  topologyApiResponse,
+} from 'types/result';
+import axiosInstance from './axiosInstance';
+
+/// 유사도 분석 결과 그래프
+
+export interface fetchGraphRequest {
+  assignmentId: number;
+  weekTitle: number;
+}
+
+export const fetchGraph = async (
+  { assignmentId, weekTitle }: fetchGraphRequest,
+  token: string
+) => {
+  const response = await axiosInstance.get<graphApiResponse>(
+    `api/result/graph`,
+    {
+      params: { assignmentId, weekTitle },
+      headers: { Authorization: `Bearer ${token}` },
+    }
+  );
+  return response.data;
+};
+
+/// 유사도 네트워크 토폴로지
+
+export const fetchTopology = async (
+  { assignmentId, weekTitle }: fetchGraphRequest,
+  token: string
+) => {
+  const response = await axiosInstance.get<topologyApiResponse>(
+    `api/result/topology`,
+    {
+      params: { assignmentId, weekTitle },
+      headers: { Authorization: `Bearer ${token}` },
+    }
+  );
+  return response.data;
+};
+
+/// 유사도 코드 비교
+
+export interface compareRequest {
+  student1: string;
+  student2: string;
+}
+
+export const fetchCompare = async (
+  { student1, student2 }: compareRequest,
+  token: string
+) => {
+  const response = await axiosInstance.get<compareApiResponse>(
+    `api/result/compare`,
+    {
+      params: { student1, student2 },
+      headers: { Authorization: `Bearer ${token}` },
+    }
+  );
+  return response.data;
+};
+
+/// 표절 판단
+
+export const fetchJudge = async (
+  { student1, student2 }: compareRequest,
+  token: string
+) => {
+  const response = await axiosInstance.get<judgeApiResponse>(
+    `api/result/judge`,
+    {
+      params: { student1, student2 },
+      headers: { Authorization: `Bearer ${token}` },
+    }
+  );
+  return response.data;
+};
+
+/// 결과 저장
+
+export interface saveStudent {
+  id: string;
+  name: string;
+  submittedTime: string;
+}
+
+export interface saveRequest {
+  userId: string;
+  plagiarize: boolean;
+  student1: saveStudent;
+  student2: saveStudent;
+}
+
+export const save = async (
+  { userId, plagiarize, student1, student2 }: saveRequest,
+  token: string
+) => {
+  const formData = new FormData();
+  formData.append('userId', userId);
+  formData.append('plagiarize', String(plagiarize));
+  formData.append('student1', String(student1));
+  formData.append('student2', String(student2));
+
+  const response = await axiosInstance.post<saveApiResponse>(
+    `api/result/save`,
+    formData,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+    }
+  );
+  return response.data;
+};

--- a/src/services/result.ts
+++ b/src/services/result.ts
@@ -13,7 +13,6 @@ import { judgeMock } from '@mocks/judgeMock';
 import { saveMock } from '@mocks/saveMock';
 
 /// 유사도 분석 결과 그래프
-
 export interface fetchGraphRequest {
   assignmentId: number;
   weekTitle: number;
@@ -28,18 +27,22 @@ export const fetchGraph = async (
     return graphMock;
   }
 
-  const response = await axiosInstance.get<graphApiResponse>(
-    `api/result/graph`,
-    {
-      params: { assignmentId, weekTitle },
-      headers: { Authorization: `Bearer ${token}` },
-    }
-  );
-  return response.data;
+  try {
+    const response = await axiosInstance.get<graphApiResponse>(
+      `/api/result/graph`,
+      {
+        params: { assignmentId, weekTitle },
+        headers: { Authorization: `Bearer ${token}` },
+      }
+    );
+    return response.data;
+  } catch (error) {
+    console.error('fetchGraph error:', error);
+    throw error;
+  }
 };
 
 /// 유사도 네트워크 토폴로지
-
 export const fetchTopology = async (
   { assignmentId, weekTitle }: fetchGraphRequest,
   token: string
@@ -49,18 +52,22 @@ export const fetchTopology = async (
     return topologyMock;
   }
 
-  const response = await axiosInstance.get<topologyApiResponse>(
-    `api/result/topology`,
-    {
-      params: { assignmentId, weekTitle },
-      headers: { Authorization: `Bearer ${token}` },
-    }
-  );
-  return response.data;
+  try {
+    const response = await axiosInstance.get<topologyApiResponse>(
+      `/api/result/topology`,
+      {
+        params: { assignmentId, weekTitle },
+        headers: { Authorization: `Bearer ${token}` },
+      }
+    );
+    return response.data;
+  } catch (error) {
+    console.error('fetchTopology error:', error);
+    throw error;
+  }
 };
 
 /// 유사도 코드 비교
-
 export interface compareRequest {
   student1: string;
   student2: string;
@@ -75,18 +82,22 @@ export const fetchCompare = async (
     return compareMock;
   }
 
-  const response = await axiosInstance.get<compareApiResponse>(
-    `api/result/compare`,
-    {
-      params: { student1, student2 },
-      headers: { Authorization: `Bearer ${token}` },
-    }
-  );
-  return response.data;
+  try {
+    const response = await axiosInstance.get<compareApiResponse>(
+      `/api/result/compare`,
+      {
+        params: { student1, student2 },
+        headers: { Authorization: `Bearer ${token}` },
+      }
+    );
+    return response.data;
+  } catch (error) {
+    console.error('fetchCompare error:', error);
+    throw error;
+  }
 };
 
 /// 표절 판단
-
 export const fetchJudge = async (
   { student1, student2 }: compareRequest,
   token: string
@@ -96,18 +107,22 @@ export const fetchJudge = async (
     return judgeMock;
   }
 
-  const response = await axiosInstance.get<judgeApiResponse>(
-    `api/result/judge`,
-    {
-      params: { student1, student2 },
-      headers: { Authorization: `Bearer ${token}` },
-    }
-  );
-  return response.data;
+  try {
+    const response = await axiosInstance.get<judgeApiResponse>(
+      `/api/result/judge`,
+      {
+        params: { student1, student2 },
+        headers: { Authorization: `Bearer ${token}` },
+      }
+    );
+    return response.data;
+  } catch (error) {
+    console.error('fetchJudge error:', error);
+    throw error;
+  }
 };
 
 /// 결과 저장
-
 export interface saveStudent {
   id: string;
   name: string;
@@ -130,18 +145,23 @@ export const save = async (
     return saveMock;
   }
 
-  const formData = new FormData();
-  formData.append('userId', userId);
-  formData.append('plagiarize', String(plagiarize));
-  formData.append('student1', JSON.stringify(student1));
-  formData.append('student2', JSON.stringify(student2));
+  try {
+    const formData = new FormData();
+    formData.append('userId', userId);
+    formData.append('plagiarize', String(plagiarize));
+    formData.append('student1', JSON.stringify(student1));
+    formData.append('student2', JSON.stringify(student2));
 
-  const response = await axiosInstance.post<saveApiResponse>(
-    `api/result/save`,
-    formData,
-    {
-      headers: { Authorization: `Bearer ${token}` },
-    }
-  );
-  return response.data;
+    const response = await axiosInstance.post<saveApiResponse>(
+      `/api/result/save`,
+      formData,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      }
+    );
+    return response.data;
+  } catch (error) {
+    console.error('save result error:', error);
+    throw error;
+  }
 };

--- a/src/services/result.ts
+++ b/src/services/result.ts
@@ -14,7 +14,7 @@ import { saveMock } from '@mocks/saveMock';
 
 /// 유사도 분석 결과 그래프
 export interface fetchGraphRequest {
-  assignmentId: number;
+  assignmentId: string;
   weekTitle: number;
 }
 

--- a/src/services/result.ts
+++ b/src/services/result.ts
@@ -6,6 +6,11 @@ import {
   topologyApiResponse,
 } from 'types/result';
 import axiosInstance from './axiosInstance';
+import { graphMock } from 'mocks/graphMock';
+import { topologyMock } from 'mocks/topologyMock';
+import { compareMock } from 'mocks/compareMock';
+import { judgeMock } from 'mocks/judgeMock';
+import { saveMock } from 'mocks/saveMock';
 
 /// 유사도 분석 결과 그래프
 
@@ -17,7 +22,12 @@ export interface fetchGraphRequest {
 export const fetchGraph = async (
   { assignmentId, weekTitle }: fetchGraphRequest,
   token: string
-) => {
+): Promise<graphApiResponse> => {
+  if (import.meta.env.VITE_USE_MOCK === 'true') {
+    await new Promise((r) => setTimeout(r, 300));
+    return graphMock;
+  }
+
   const response = await axiosInstance.get<graphApiResponse>(
     `api/result/graph`,
     {
@@ -33,7 +43,12 @@ export const fetchGraph = async (
 export const fetchTopology = async (
   { assignmentId, weekTitle }: fetchGraphRequest,
   token: string
-) => {
+): Promise<topologyApiResponse> => {
+  if (import.meta.env.VITE_USE_MOCK === 'true') {
+    await new Promise((r) => setTimeout(r, 300));
+    return topologyMock;
+  }
+
   const response = await axiosInstance.get<topologyApiResponse>(
     `api/result/topology`,
     {
@@ -54,7 +69,12 @@ export interface compareRequest {
 export const fetchCompare = async (
   { student1, student2 }: compareRequest,
   token: string
-) => {
+): Promise<compareApiResponse> => {
+  if (import.meta.env.VITE_USE_MOCK === 'true') {
+    await new Promise((r) => setTimeout(r, 300));
+    return compareMock;
+  }
+
   const response = await axiosInstance.get<compareApiResponse>(
     `api/result/compare`,
     {
@@ -70,7 +90,12 @@ export const fetchCompare = async (
 export const fetchJudge = async (
   { student1, student2 }: compareRequest,
   token: string
-) => {
+): Promise<judgeApiResponse> => {
+  if (import.meta.env.VITE_USE_MOCK === 'true') {
+    await new Promise((r) => setTimeout(r, 300));
+    return judgeMock;
+  }
+
   const response = await axiosInstance.get<judgeApiResponse>(
     `api/result/judge`,
     {
@@ -99,7 +124,12 @@ export interface saveRequest {
 export const save = async (
   { userId, plagiarize, student1, student2 }: saveRequest,
   token: string
-) => {
+): Promise<saveApiResponse> => {
+  if (import.meta.env.VITE_USE_MOCK === 'true') {
+    await new Promise((r) => setTimeout(r, 300));
+    return saveMock;
+  }
+
   const formData = new FormData();
   formData.append('userId', userId);
   formData.append('plagiarize', String(plagiarize));

--- a/src/services/result.ts
+++ b/src/services/result.ts
@@ -133,8 +133,8 @@ export const save = async (
   const formData = new FormData();
   formData.append('userId', userId);
   formData.append('plagiarize', String(plagiarize));
-  formData.append('student1', String(student1));
-  formData.append('student2', String(student2));
+  formData.append('student1', JSON.stringify(student1));
+  formData.append('student2', JSON.stringify(student2));
 
   const response = await axiosInstance.post<saveApiResponse>(
     `api/result/save`,

--- a/src/services/result.ts
+++ b/src/services/result.ts
@@ -6,11 +6,11 @@ import {
   topologyApiResponse,
 } from 'types/result';
 import axiosInstance from './axiosInstance';
-import { graphMock } from 'mocks/graphMock';
-import { topologyMock } from 'mocks/topologyMock';
-import { compareMock } from 'mocks/compareMock';
-import { judgeMock } from 'mocks/judgeMock';
-import { saveMock } from 'mocks/saveMock';
+import { graphMock } from '@mocks/graphMock';
+import { topologyMock } from '@mocks/topologyMock';
+import { compareMock } from '@mocks/compareMock';
+import { judgeMock } from '@mocks/judgeMock';
+import { saveMock } from '@mocks/saveMock';
 
 /// 유사도 분석 결과 그래프
 

--- a/src/services/submit.ts
+++ b/src/services/submit.ts
@@ -1,0 +1,172 @@
+import {
+  addAssignmentApiResponse,
+  addSubjectApiResponse,
+  addWeekApiResponse,
+  analyzeApiResponse,
+  uploadApiResponse,
+  viewSubjectApiResponse,
+} from 'types/submit';
+import axiosInstance from './axiosInstance';
+
+/// 새로운 과목 추가
+
+export interface addSubjectRequest {
+  subjectName: string;
+}
+
+export const addSubject = async (
+  { subjectName }: addSubjectRequest,
+  token: string
+) => {
+  const formData = new FormData();
+  formData.append('subjectName', subjectName);
+
+  const response = await axiosInstance.post<addSubjectApiResponse>(
+    `api/submit/subjects`,
+    formData,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+    }
+  );
+  return response.data;
+};
+
+/// 기존 과목 조회
+
+export const fetchSubject = async (token: string) => {
+  const response = await axiosInstance.get<viewSubjectApiResponse>(
+    `api/submit/subjects`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+    }
+  );
+  return response.data;
+};
+
+/// 과제 생성
+
+export interface addAssignmentRequest {
+  assignmentId: string;
+  assignmentName: string;
+}
+
+export const addAssignment = async (
+  { assignmentId, assignmentName }: addAssignmentRequest,
+  token: string
+) => {
+  const formData = new FormData();
+  formData.append('assignmentId', assignmentId);
+  formData.append('assignmentName', assignmentName);
+
+  const response = await axiosInstance.post<addAssignmentApiResponse>(
+    `api/submit/assignment`,
+    formData,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+    }
+  );
+  return response.data;
+};
+
+/// 주차 생성
+
+export interface addWeekRequest {
+  assignmentId: number;
+  startDate: string;
+  endDate: string;
+  weekTitle: number;
+}
+
+export const addWeek = async (
+  { assignmentId, startDate, endDate, weekTitle }: addWeekRequest,
+  token: string
+) => {
+  const formData = new FormData();
+  formData.append('assignmentId', String(assignmentId));
+  formData.append('startDate', startDate);
+  formData.append('endDate', endDate);
+  formData.append('weekTitle', String(weekTitle));
+
+  const response = await axiosInstance.post<addWeekApiResponse>(
+    `api/submit/week`,
+    formData,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+    }
+  );
+  return response.data;
+};
+
+/// 파일 업로드
+
+export interface PresignedUrlRequest {
+  fileName: string;
+  contentType: string;
+}
+
+export interface PresignedUrlResponse {
+  url: string; // presigned upload URL
+  key: string; // S3 object key
+}
+
+export const getPresignedUrl = async (
+  { fileName, contentType }: PresignedUrlRequest,
+  token: string
+): Promise<PresignedUrlResponse> => {
+  const response = await axiosInstance.post<PresignedUrlResponse>(
+    `api/s3/presign`, // 실제 백엔드 presigned URL 발급 API 경로로 수정 필요
+    { fileName, contentType },
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    }
+  );
+  return response.data;
+};
+
+export const uploadFileToS3 = async (presignedUrl: string, file: File) => {
+  await fetch(presignedUrl, {
+    method: 'PUT',
+    headers: {
+      'Conent-Type': file.type,
+    },
+    body: file,
+  });
+};
+
+export interface UploadMetadataRequest {
+  assignmentId: number;
+  fileName: string;
+  s3Key: string;
+  fileType: string;
+  uploadAt: string;
+}
+
+export const submitUploadMetadata = async (
+  data: UploadMetadataRequest,
+  token: string
+): Promise<uploadApiResponse> => {
+  const response = await axiosInstance.post<uploadApiResponse>(
+    `api/submit/upload`,
+    data,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    }
+  );
+  return response.data;
+};
+
+/// 유사도 분석
+
+export const fetchAnalyze = async (token: string) => {
+  const response = await axiosInstance.get<analyzeApiResponse>(
+    `api/submit/analyze`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+    }
+  );
+  return response.data;
+};

--- a/src/services/submit.ts
+++ b/src/services/submit.ts
@@ -7,12 +7,12 @@ import {
   viewSubjectApiResponse,
 } from 'types/submit';
 import axiosInstance from './axiosInstance';
-import { addSubjectMock } from 'mocks/addSubjectMock';
-import { viewSubjectMock } from 'mocks/viewSubjectMock';
-import { addAssignmentMock } from 'mocks/addAssignmentMock';
-import { addWeekMock } from 'mocks/addWeekMock';
-import { uploadMock } from 'mocks/uploadMock';
-import { analyzeMock } from 'mocks/analyzeMock';
+import { addSubjectMock } from '@mocks/addSubjectMock';
+import { viewSubjectMock } from '@mocks/viewSubjectMock';
+import { addAssignmentMock } from '@mocks/addAssignmentMock';
+import { addWeekMock } from '@mocks/addWeekMock';
+import { uploadMock } from '@mocks/uploadMock';
+import { analyzeMock } from '@mocks/analyzeMock';
 
 /// 새로운 과목 추가
 

--- a/src/services/submit.ts
+++ b/src/services/submit.ts
@@ -29,16 +29,17 @@ export const addSubject = async (
     return addSubjectMock;
   }
 
-  const formData = new FormData();
-  formData.append('subjectName', subjectName);
-
   const response = await axiosInstance.post<addSubjectApiResponse>(
     `/api/submit/subjects`,
-    formData,
+    { subjectName },
     {
-      headers: { Authorization: `Bearer ${token}` },
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
     }
   );
+
   return response.data;
 };
 
@@ -64,12 +65,12 @@ export const fetchSubject = async (
 /// 과제 생성
 
 export interface addAssignmentRequest {
-  assignmentId: string;
+  subjectName: string;
   assignmentName: string;
 }
 
 export const addAssignment = async (
-  { assignmentId, assignmentName }: addAssignmentRequest,
+  { subjectName, assignmentName }: addAssignmentRequest,
   token: string
 ): Promise<addAssignmentApiResponse> => {
   if (import.meta.env.VITE_USE_MOCK === 'true') {
@@ -77,15 +78,14 @@ export const addAssignment = async (
     return addAssignmentMock;
   }
 
-  const formData = new FormData();
-  formData.append('assignmentId', assignmentId);
-  formData.append('assignmentName', assignmentName);
-
   const response = await axiosInstance.post<addAssignmentApiResponse>(
-    `/api/submit/assignment`,
-    formData,
+    `api/submit/assignment`,
+    { subjectName, assignmentName },
     {
-      headers: { Authorization: `Bearer ${token}` },
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
     }
   );
   return response.data;
@@ -94,7 +94,7 @@ export const addAssignment = async (
 /// 주차 생성
 
 export interface addWeekRequest {
-  assignmentId: number;
+  assignmentId: string;
   startDate: string;
   endDate: string;
   weekTitle: number;
@@ -109,17 +109,19 @@ export const addWeek = async (
     return addWeekMock;
   }
 
-  const formData = new FormData();
-  formData.append('assignmentId', String(assignmentId));
-  formData.append('startDate', startDate);
-  formData.append('endDate', endDate);
-  formData.append('weekTitle', String(weekTitle));
-
   const response = await axiosInstance.post<addWeekApiResponse>(
     `/api/submit/week`,
-    formData,
     {
-      headers: { Authorization: `Bearer ${token}` },
+      assignmentId,
+      startDate,
+      endDate,
+      weekTitle,
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
     }
   );
   return response.data;
@@ -164,7 +166,7 @@ export const uploadFileToS3 = async (presignedUrl: string, file: File) => {
 };
 
 export interface UploadMetadataRequest {
-  assignmentId: number;
+  assignmentId: string;
   fileName: string;
   s3Key: string;
   fileType: string;
@@ -186,6 +188,7 @@ export const submitUploadMetadata = async (
     {
       headers: {
         Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
       },
     }
   );

--- a/src/services/submit.ts
+++ b/src/services/submit.ts
@@ -157,7 +157,7 @@ export const uploadFileToS3 = async (presignedUrl: string, file: File) => {
   await fetch(presignedUrl, {
     method: 'PUT',
     headers: {
-      'Conent-Type': file.type,
+      'Content-Type': file.type,
     },
     body: file,
   });

--- a/src/services/submit.ts
+++ b/src/services/submit.ts
@@ -33,7 +33,7 @@ export const addSubject = async (
   formData.append('subjectName', subjectName);
 
   const response = await axiosInstance.post<addSubjectApiResponse>(
-    `api/submit/subjects`,
+    `/api/submit/subjects`,
     formData,
     {
       headers: { Authorization: `Bearer ${token}` },
@@ -53,7 +53,7 @@ export const fetchSubject = async (
   }
 
   const response = await axiosInstance.get<viewSubjectApiResponse>(
-    `api/submit/subjects`,
+    `/api/submit/subjects`,
     {
       headers: { Authorization: `Bearer ${token}` },
     }
@@ -82,7 +82,7 @@ export const addAssignment = async (
   formData.append('assignmentName', assignmentName);
 
   const response = await axiosInstance.post<addAssignmentApiResponse>(
-    `api/submit/assignment`,
+    `/api/submit/assignment`,
     formData,
     {
       headers: { Authorization: `Bearer ${token}` },
@@ -116,7 +116,7 @@ export const addWeek = async (
   formData.append('weekTitle', String(weekTitle));
 
   const response = await axiosInstance.post<addWeekApiResponse>(
-    `api/submit/week`,
+    `/api/submit/week`,
     formData,
     {
       headers: { Authorization: `Bearer ${token}` },
@@ -142,7 +142,7 @@ export const getPresignedUrl = async (
   token: string
 ): Promise<PresignedUrlResponse> => {
   const response = await axiosInstance.post<PresignedUrlResponse>(
-    `api/s3/presign`, // 실제 백엔드 presigned URL 발급 API 경로로 수정 필요
+    `/api/s3/presign`, // 실제 백엔드 presigned URL 발급 API 경로로 수정 필요
     { fileName, contentType },
     {
       headers: {
@@ -181,7 +181,7 @@ export const submitUploadMetadata = async (
   }
 
   const response = await axiosInstance.post<uploadApiResponse>(
-    `api/submit/upload`,
+    `/api/submit/upload`,
     data,
     {
       headers: {
@@ -203,7 +203,7 @@ export const fetchAnalyze = async (
   }
 
   const response = await axiosInstance.get<analyzeApiResponse>(
-    `api/submit/analyze`,
+    `/api/submit/analyze`,
     {
       headers: { Authorization: `Bearer ${token}` },
     }

--- a/src/services/submit.ts
+++ b/src/services/submit.ts
@@ -164,13 +164,19 @@ export const getPresignedUrl = async (
 };
 
 export const uploadFileToS3 = async (presignedUrl: string, file: File) => {
-  await fetch(presignedUrl, {
+  const response = await fetch(presignedUrl, {
     method: 'PUT',
     headers: {
       'Content-Type': file.type,
     },
     body: file,
   });
+
+  if (!response.ok) {
+    throw new Error(
+      `S3 업로드 실패: ${response.status} ${response.statusText}`
+    );
+  }
 };
 
 export interface UploadMetadataRequest {

--- a/src/services/submit.ts
+++ b/src/services/submit.ts
@@ -7,6 +7,12 @@ import {
   viewSubjectApiResponse,
 } from 'types/submit';
 import axiosInstance from './axiosInstance';
+import { addSubjectMock } from 'mocks/addSubjectMock';
+import { viewSubjectMock } from 'mocks/viewSubjectMock';
+import { addAssignmentMock } from 'mocks/addAssignmentMock';
+import { addWeekMock } from 'mocks/addWeekMock';
+import { uploadMock } from 'mocks/uploadMock';
+import { analyzeMock } from 'mocks/analyzeMock';
 
 /// 새로운 과목 추가
 
@@ -17,7 +23,12 @@ export interface addSubjectRequest {
 export const addSubject = async (
   { subjectName }: addSubjectRequest,
   token: string
-) => {
+): Promise<addSubjectApiResponse> => {
+  if (import.meta.env.VITE_USE_MOCK === 'true') {
+    await new Promise((r) => setTimeout(r, 300));
+    return addSubjectMock;
+  }
+
   const formData = new FormData();
   formData.append('subjectName', subjectName);
 
@@ -33,7 +44,14 @@ export const addSubject = async (
 
 /// 기존 과목 조회
 
-export const fetchSubject = async (token: string) => {
+export const fetchSubject = async (
+  token: string
+): Promise<viewSubjectApiResponse> => {
+  if (import.meta.env.VITE_USE_MOCK === 'true') {
+    await new Promise((r) => setTimeout(r, 300));
+    return viewSubjectMock;
+  }
+
   const response = await axiosInstance.get<viewSubjectApiResponse>(
     `api/submit/subjects`,
     {
@@ -53,7 +71,12 @@ export interface addAssignmentRequest {
 export const addAssignment = async (
   { assignmentId, assignmentName }: addAssignmentRequest,
   token: string
-) => {
+): Promise<addAssignmentApiResponse> => {
+  if (import.meta.env.VITE_USE_MOCK === 'true') {
+    await new Promise((r) => setTimeout(r, 300));
+    return addAssignmentMock;
+  }
+
   const formData = new FormData();
   formData.append('assignmentId', assignmentId);
   formData.append('assignmentName', assignmentName);
@@ -80,7 +103,12 @@ export interface addWeekRequest {
 export const addWeek = async (
   { assignmentId, startDate, endDate, weekTitle }: addWeekRequest,
   token: string
-) => {
+): Promise<addWeekApiResponse> => {
+  if (import.meta.env.VITE_USE_MOCK === 'true') {
+    await new Promise((r) => setTimeout(r, 300));
+    return addWeekMock;
+  }
+
   const formData = new FormData();
   formData.append('assignmentId', String(assignmentId));
   formData.append('startDate', startDate);
@@ -147,6 +175,11 @@ export const submitUploadMetadata = async (
   data: UploadMetadataRequest,
   token: string
 ): Promise<uploadApiResponse> => {
+  if (import.meta.env.VITE_USE_MOCK === 'true') {
+    await new Promise((r) => setTimeout(r, 300));
+    return uploadMock;
+  }
+
   const response = await axiosInstance.post<uploadApiResponse>(
     `api/submit/upload`,
     data,
@@ -161,7 +194,14 @@ export const submitUploadMetadata = async (
 
 /// 유사도 분석
 
-export const fetchAnalyze = async (token: string) => {
+export const fetchAnalyze = async (
+  token: string
+): Promise<analyzeApiResponse> => {
+  if (import.meta.env.VITE_USE_MOCK === 'true') {
+    await new Promise((r) => setTimeout(r, 300));
+    return analyzeMock;
+  }
+
   const response = await axiosInstance.get<analyzeApiResponse>(
     `api/submit/analyze`,
     {

--- a/src/services/submit.ts
+++ b/src/services/submit.ts
@@ -143,6 +143,14 @@ export const getPresignedUrl = async (
   { fileName, contentType }: PresignedUrlRequest,
   token: string
 ): Promise<PresignedUrlResponse> => {
+  if (import.meta.env.VITE_USE_MOCK === 'true') {
+    await new Promise((r) => setTimeout(r, 300));
+    return {
+      url: 'https://mock-presigned-url.com',
+      key: `mock-key-${fileName}`,
+    };
+  }
+
   const response = await axiosInstance.post<PresignedUrlResponse>(
     `/api/s3/presign`, // 실제 백엔드 presigned URL 발급 API 경로로 수정 필요
     { fileName, contentType },

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -1,0 +1,89 @@
+/// 누적 네트워크 토폴로지
+
+export interface AccumulatedNode {
+  id: string; // 학번
+  label: string; // 이름
+}
+
+export interface AccumulatedEdge {
+  id: string; // fromId-toId 형식
+  from: string;
+  to: string;
+  count: number; // 높은 유사도 누적 횟수
+  value: number; // 평균 유사도
+  width: number; // 시각화에 사용할 굵기 정보
+}
+
+export interface AccumulatedResponseData {
+  nodes: AccumulatedNode[];
+  edges: AccumulatedEdge[];
+}
+
+export interface AccumulatedApiResponse {
+  status: number;
+  success: boolean;
+  message: AccumulatedResponseData;
+}
+
+/// 저장된 분석 기록
+
+export interface RecordNode {
+  id: string;
+  label: string;
+  submittedAt: string; // 제출 시간
+}
+
+export interface ReactWeekHistory {
+  submittedFrom: string;
+  submittedTo: string;
+  similarity: number;
+}
+
+export interface RecordWeekEdge {
+  id: string;
+  from: string;
+  to: string;
+  value: number;
+  width: number;
+  histories: ReactWeekHistory[];
+}
+
+export interface RecordEdge {
+  week: number;
+  weekData: RecordWeekEdge[];
+}
+
+export interface RecordResponseData {
+  nodes: RecordNode[];
+  edges: RecordEdge[];
+}
+
+export interface RecordApiResponse {
+  status: number;
+  success: boolean;
+  message: RecordResponseData;
+}
+
+/// 대시보드 메인
+
+export interface MainUser {
+  userId: number;
+  userName: string;
+}
+
+export interface MainSubject {
+  subjectId: number;
+  subjectName: string;
+}
+
+export interface MainResponseData {
+  user: MainUser[];
+  testCount: number; // 진행한 유사도 검사 횟수
+  subjects: MainSubject[];
+}
+
+export interface MainApiResponse {
+  status: number;
+  success: boolean;
+  message: MainResponseData;
+}

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -77,7 +77,7 @@ export interface MainSubject {
 }
 
 export interface MainResponseData {
-  user: MainUser[];
+  user: MainUser;
   testCount: number; // 진행한 유사도 검사 횟수
   subjects: MainSubject[];
 }

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -33,7 +33,7 @@ export interface RecordNode {
   submittedAt: string; // 제출 시간
 }
 
-export interface ReactWeekHistory {
+export interface RecordWeekHistory {
   submittedFrom: string;
   submittedTo: string;
   similarity: number;
@@ -45,7 +45,7 @@ export interface RecordWeekEdge {
   to: string;
   value: number;
   width: number;
-  histories: ReactWeekHistory[];
+  histories: RecordWeekHistory[];
 }
 
 export interface RecordEdge {

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -45,7 +45,7 @@ export interface topologyRelatedFiles {
 export interface topologyNode {
   id: string;
   label: string;
-  fildeName: string;
+  fileName: string;
   submittedAt: string;
   relatedFiles: topologyRelatedFiles[];
 }

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -96,6 +96,12 @@ export interface compareResponseData {
   student2: compareStudent;
 }
 
+export interface compareApiResponse {
+  status: number;
+  success: boolean;
+  message: compareResponseData;
+}
+
 /// 표절 판단
 
 export interface judgeStudent {
@@ -118,21 +124,7 @@ export interface judgeApiResponse {
 
 /// 결과 저장
 
-export interface saveStudent {
-  id: string;
-  name: string;
-  submittedTime: string;
-}
-
-export interface saveResponseData {
-  userId: string;
-  plagiarize: boolean;
-  student1: saveStudent;
-  student2: saveStudent;
-}
-
 export interface saveApiResponse {
   status: number;
   success: boolean;
-  message: saveResponseData;
 }

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -26,7 +26,7 @@ export interface graphFilteredPair {
 export interface graphResponseData {
   nodes: graphNode[];
   filterSummary: graphFilterSummary;
-  filteredPairs: graphFilteredPair[];
+  filteredPairs: graphFilteredPair;
 }
 
 export interface graphApiResponse {
@@ -62,7 +62,7 @@ export interface topologyEdge {
   value: number;
   width: number;
   comparedFiles: string;
-  histories: topologyEdgeHistory;
+  histories: topologyEdgeHistory[];
 }
 
 export interface topologyResponseData {

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -1,0 +1,138 @@
+/// 유사도 분석 결과 그래프
+
+export interface graphNode {
+  id: string;
+  label: string;
+}
+
+export interface graphFilterSummary {
+  total: number; // 검사된 총 파일 갯수
+  aboveThreshold: number; // 유사도 임계선을 넘은 파일 갯수
+  belowThreshold: number; // 유사도 임계선에 못 미치는 파일 갯수
+  threshold: number; // 유사도 임계값
+}
+
+export interface graphPairThreshold {
+  from: string;
+  to: string;
+  similarity: number;
+}
+
+export interface graphFilteredPair {
+  aboveThreshold: graphPairThreshold[];
+  belowThreshold: graphPairThreshold[];
+}
+
+export interface graphResponseData {
+  nodes: graphNode[];
+  filterSummary: graphFilterSummary;
+  filteredPairs: graphFilteredPair[];
+}
+
+export interface graphApiResponse {
+  status: number;
+  success: boolean;
+  message: graphResponseData;
+}
+
+/// 유사도 네트워크 토폴로지
+
+export interface topologyRelatedFiles {
+  fileName: string;
+  similarity: number;
+}
+
+export interface topologyNode {
+  id: string;
+  label: string;
+  fildeName: string;
+  submittedAt: string;
+  relatedFiles: topologyRelatedFiles[];
+}
+
+export interface topologyEdgeHistory {
+  submittedFrom: string;
+  submittedTo: string;
+}
+
+export interface topologyEdge {
+  id: string;
+  from: string;
+  to: string;
+  value: number;
+  width: number;
+  comparedFiles: string;
+  histories: topologyEdgeHistory;
+}
+
+export interface topologyResponseData {
+  nodes: topologyNode[];
+  edges: topologyEdge[];
+}
+
+export interface topologyApiResponse {
+  status: number;
+  success: boolean;
+  message: topologyResponseData;
+}
+
+/// 유사도 코드 비교
+
+export interface compareCode {
+  code: string[];
+  lines: number[];
+}
+
+export interface compareStudent {
+  id: string;
+  name: string;
+  fileName: string;
+  submissionTime: string;
+  code: compareCode;
+}
+
+export interface compareResponseData {
+  student1: compareStudent;
+  student2: compareStudent;
+}
+
+/// 표절 판단
+
+export interface judgeStudent {
+  id: string;
+  name: string;
+  submittedTime: string;
+}
+
+export interface judgeResponseData {
+  similarity: number;
+  student1: judgeStudent;
+  student2: judgeStudent;
+}
+
+export interface judgeApiResponse {
+  status: number;
+  success: boolean;
+  message: judgeResponseData;
+}
+
+/// 결과 저장
+
+export interface saveStudent {
+  id: string;
+  name: string;
+  submittedTime: string;
+}
+
+export interface saveResponseData {
+  userId: string;
+  plagiarize: boolean;
+  student1: saveStudent;
+  student2: saveStudent;
+}
+
+export interface saveApiResponse {
+  status: number;
+  success: boolean;
+  message: saveResponseData;
+}

--- a/src/types/submit.ts
+++ b/src/types/submit.ts
@@ -24,7 +24,7 @@ export interface viewSubjectApiResponse {
 // 과제 생성
 
 export interface addAssignmentResult {
-  assignmentId: number;
+  assignmentId: string;
   message: string;
 }
 

--- a/src/types/submit.ts
+++ b/src/types/submit.ts
@@ -1,0 +1,74 @@
+/// 새로운 과목 추가
+
+export interface addSubjectResult {
+  subjectId: number;
+  message: string; // 성공 여부 안내 메시지
+}
+
+export interface addSubjectApiResponse {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: addSubjectResult[];
+}
+
+/// 기존 과목 조회
+
+export interface viewSubjectApiResponse {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: string[];
+}
+
+// 과제 생성
+
+export interface addAssignmentResult {
+  assignmentId: number;
+  message: string;
+}
+
+export interface addAssignmentApiResponse {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: addAssignmentResult[];
+}
+
+/// 주차 생성
+
+export interface addWeekResult {
+  message: string;
+}
+
+export interface addWeekApiResponse {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: addWeekResult;
+}
+
+/// 파일 업로드
+
+export interface uploadResult {
+  message: string;
+}
+
+export interface uploadApiResponse {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: uploadResult;
+}
+
+/// 유사도 분석
+
+export interface analyzeResponseData {
+  status: string;
+}
+
+export interface analyzeApiResponse {
+  status: number;
+  success: boolean;
+  message: analyzeResponseData;
+}

--- a/src/types/submit.ts
+++ b/src/types/submit.ts
@@ -9,7 +9,7 @@ export interface addSubjectApiResponse {
   isSuccess: boolean;
   code: string;
   message: string;
-  result: addSubjectResult[];
+  result: addSubjectResult;
 }
 
 /// 기존 과목 조회
@@ -32,7 +32,7 @@ export interface addAssignmentApiResponse {
   isSuccess: boolean;
   code: string;
   message: string;
-  result: addAssignmentResult[];
+  result: addAssignmentResult;
 }
 
 /// 주차 생성

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
       '@services': path.resolve(__dirname, 'src/services'),
       '@utils': path.resolve(__dirname, 'src/utils'),
       '@constants': path.resolve(__dirname, 'src/constants'),
+      '@mocks': path.resolve(__dirname, '/src/mocks'),
     },
   },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
       '@services': path.resolve(__dirname, 'src/services'),
       '@utils': path.resolve(__dirname, 'src/utils'),
       '@constants': path.resolve(__dirname, 'src/constants'),
-      '@mocks': path.resolve(__dirname, '/src/mocks'),
+      '@mocks': path.resolve(__dirname, 'src/mocks'),
     },
   },
 });


### PR DESCRIPTION
## ✅ 변경 사항

- `axios` 기반 api 요청 함수 작성 -> `/services`
- mock 데이터 생성 -> `/mocks`
- React Query 기반 커스텀 훅 작성 -> `/hooks`
- 컴포넌트에 연동하여 UI 및 상태 연동 테스트 -> 'selectSubjectPage.tsx`에서만 임시 진행

## 📂 관련 이슈

- #24


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**새로운 기능**
  * React Query 기반의 데이터 요청 및 캐싱 기능이 도입되어, 과제, 주차, 대시보드, 유사도 분석 등 다양한 데이터가 실시간으로 동기화됩니다.
  * 과목 선택 페이지가 동적 데이터와 비동기 과목 추가를 지원하도록 개선되었습니다.
  * 다양한 커스텀 React Query 훅이 추가되어 대시보드, 유사도 그래프, 코드 비교, 표절 판정, 파일 업로드 등 주요 기능을 제공합니다.

**버그 수정**
  * 과목 선택 시 이름 기준으로 동작하도록 로직이 개선되었습니다.

**문서화**
  * 타입스크립트 기반의 API 응답, 대시보드, 결과, 제출 관련 타입이 체계적으로 정의되었습니다.

**환경 및 설정**
  * React Query 도입 및 Vite alias(@mocks) 추가로 개발 환경이 개선되었습니다.
  * axios, react-query 등 주요 라이브러리 의존성이 최신화되었습니다.

**테스트 및 목 데이터**
  * 대시보드, 과제, 주차, 분석, 비교, 판정, 업로드 등 다양한 기능에 대한 목(mock) 데이터가 추가되어 개발 및 테스트 편의성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->