### PR TITLE
FEAT: 대시보드 관련 API 연동

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,7 +41,7 @@ const App: React.FC = () => {
           <Route path="/compare/:from/:to" element={<ComparePage />} />
           <Route path="/decision" element={<PlagiarismDecisionPage />} />
           <Route path="/dashboard" element={<DashboardPage />} />
-          <Route path="/record/detail" element={<SavedRecordDetailPage />} />
+          <Route path="/record/:recordId" element={<SavedRecordDetailPage />} />
           <Route path="/login" element={<LoginPage />} />
           <Route path="/signup" element={<SignupPage />} />
         </Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import HomePage from '@features/Home/HomePage';
 import SignupPage from '@features/Account/SignupPage';
 import GlobalLoading from '@components/GlobalLoading';
 import SubjectSelectPage from '@features/Assignment/SubjectSelectPage';
+import SavedRecordDetailPage from '@features/Dashboard/History/SavedRecordDetailPage';
 
 const App: React.FC = () => {
   return (
@@ -40,6 +41,7 @@ const App: React.FC = () => {
           <Route path="/compare/:from/:to" element={<ComparePage />} />
           <Route path="/decision" element={<PlagiarismDecisionPage />} />
           <Route path="/dashboard" element={<DashboardPage />} />
+          <Route path="/record/detail" element={<SavedRecordDetailPage />} />
           <Route path="/login" element={<LoginPage />} />
           <Route path="/signup" element={<SignupPage />} />
         </Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,7 +41,10 @@ const App: React.FC = () => {
           <Route path="/compare/:from/:to" element={<ComparePage />} />
           <Route path="/decision" element={<PlagiarismDecisionPage />} />
           <Route path="/dashboard" element={<DashboardPage />} />
-          <Route path="/record/:recordId" element={<SavedRecordDetailPage />} />
+          <Route
+            path="/subjects/:subjectId/record/:recordId"
+            element={<SavedRecordDetailPage />}
+          />
           <Route path="/login" element={<LoginPage />} />
           <Route path="/signup" element={<SignupPage />} />
         </Routes>

--- a/src/components/LoadingState.tsx
+++ b/src/components/LoadingState.tsx
@@ -1,0 +1,16 @@
+import Text from '@components/Text';
+
+export const LoadingSkeleton = () => (
+  <div className="rounded-2xl bg-blue-50 p-6 ring-1 ring-blue-100">
+    <div className="h-6 w-48 animate-pulse rounded bg-white/70" />
+    <div className="mt-2 h-4 w-32 animate-pulse rounded bg-white/60" />
+  </div>
+);
+
+export const ErrorState = ({ message }: { message?: string }) => (
+  <div className="rounded-2xl bg-red-50 p-6 ring-1 ring-red-100">
+    <Text variant="body" className="text-red-700">
+      {message ?? '데이터를 불러오지 못했습니다.'}
+    </Text>
+  </div>
+);

--- a/src/features/Dashboard/DashboardMain.tsx
+++ b/src/features/Dashboard/DashboardMain.tsx
@@ -1,17 +1,16 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import Text from '@components/Text';
 import { useSubjectStore } from '@stores/useSubjectStore';
 import AccumulatedSimilarityGraph from './AccumulatedSimilarityGraph';
 import SavedAnalysisSection from './History/SavedAnalysisSection';
-import { dummySavedRecords } from '@constants/dummySavedRecords';
-import { useSavedRecordStore } from '@stores/useSavedRecordStore';
+import { useRecord } from '@hooks/useRecord';
+import { ErrorState, LoadingSkeleton } from '@components/LoadingState';
 
 const DashboardMain: React.FC = () => {
   const { selectedSubject } = useSubjectStore();
+  const subjectId = selectedSubject ? Number(selectedSubject.id) : undefined;
 
-  useEffect(() => {
-    useSavedRecordStore.getState().setRecords(dummySavedRecords);
-  }, []);
+  const { data, isLoading, isError } = useRecord(subjectId);
 
   if (!selectedSubject) {
     return (
@@ -28,6 +27,10 @@ const DashboardMain: React.FC = () => {
       </div>
     );
   }
+
+  // 로딩/에러
+  if (isLoading) return <LoadingSkeleton />;
+  if (isError || !data) return <ErrorState />;
 
   return (
     <main className="py-8">

--- a/src/features/Dashboard/History/SavedAnalysisDummy.ts
+++ b/src/features/Dashboard/History/SavedAnalysisDummy.ts
@@ -1,54 +1,54 @@
-import { SavedAnalysisRecord } from './SavedAnalysisType';
+// import { SavedAnalysisRecord } from './SavedAnalysisType';
 
-export const savedAnalysisRecords: SavedAnalysisRecord[] = [
-  {
-    id: 'r001',
-    assignmentName: '프로그래밍 입문',
-    week: 1,
-    type: 'group',
-    savedAt: '2025-03-30T10:00:00',
-  },
-  {
-    id: 'r002',
-    assignmentName: '프로그래밍 입문',
-    week: 1,
-    type: 'pair',
-    fileA: {
-      id: '3',
-      label: '학생3',
-      submittedAt: '2025-03-29 17:00',
-    },
-    fileB: {
-      id: '4',
-      label: '학생4',
-      submittedAt: '2025-03-29 17:01',
-    },
-    similarity: 95,
-    savedAt: '2025-03-30T10:01:00',
-  },
-  {
-    id: 'r003',
-    assignmentName: '프로그래밍 입문',
-    week: 2,
-    type: 'group',
-    savedAt: '2025-04-02T09:20:00',
-  },
-  {
-    id: 'r004',
-    assignmentName: '프로그래밍 입문',
-    week: 2,
-    type: 'pair',
-    fileA: {
-      id: '3',
-      label: '학생3',
-      submittedAt: '2025-04-01 17:00',
-    },
-    fileB: {
-      id: '4',
-      label: '학생4',
-      submittedAt: '2025-04-01 17:01',
-    },
-    similarity: 95,
-    savedAt: '2025-04-02T09:22:00',
-  },
-];
+// export const savedAnalysisRecords: SavedAnalysisRecord[] = [
+//   {
+//     id: 'r001',
+//     assignmentName: '프로그래밍 입문',
+//     week: 1,
+//     type: 'group',
+//     savedAt: '2025-03-30T10:00:00',
+//   },
+//   {
+//     id: 'r002',
+//     assignmentName: '프로그래밍 입문',
+//     week: 1,
+//     type: 'pair',
+//     fileA: {
+//       id: '3',
+//       label: '학생3',
+//       submittedAt: '2025-03-29 17:00',
+//     },
+//     fileB: {
+//       id: '4',
+//       label: '학생4',
+//       submittedAt: '2025-03-29 17:01',
+//     },
+//     similarity: 95,
+//     savedAt: '2025-03-30T10:01:00',
+//   },
+//   {
+//     id: 'r003',
+//     assignmentName: '프로그래밍 입문',
+//     week: 2,
+//     type: 'group',
+//     savedAt: '2025-04-02T09:20:00',
+//   },
+//   {
+//     id: 'r004',
+//     assignmentName: '프로그래밍 입문',
+//     week: 2,
+//     type: 'pair',
+//     fileA: {
+//       id: '3',
+//       label: '학생3',
+//       submittedAt: '2025-04-01 17:00',
+//     },
+//     fileB: {
+//       id: '4',
+//       label: '학생4',
+//       submittedAt: '2025-04-01 17:01',
+//     },
+//     similarity: 95,
+//     savedAt: '2025-04-02T09:22:00',
+//   },
+// ];

--- a/src/features/Dashboard/History/SavedAnalysisItem.tsx
+++ b/src/features/Dashboard/History/SavedAnalysisItem.tsx
@@ -39,7 +39,8 @@ const SavedAnalysisItem: React.FC<Props> = ({ record }) => {
   // pair
   const similarityText = formatPercent01(record.similarity ?? 0);
   const aTime = formatDateTimeKST(record.fileA.submittedAt);
-  const bTime = formatDateTimeKST(record.fileB.submittedAt);
+  const bTime = formatDateTimeKST(record.fileB?.submittedAt || '');
+  const bLabel = record.fileB?.label ?? '(미제출)';
 
   return (
     <div className="flex flex-col items-center">
@@ -63,15 +64,15 @@ const SavedAnalysisItem: React.FC<Props> = ({ record }) => {
             <span className="text-blue-600">{aTime}</span>
           </div>
           <div>
-            <span className="font-medium">{record.fileB.label}</span>{' '}
+            <span className="font-medium">{bLabel}</span>{' '}
             <span className="text-blue-600">{bTime}</span>
           </div>
         </div>
       </button>
 
       <p className="mt-2 w-full text-center font-semibold text-gray-600">
-        &lt;{record.assignmentName}&gt; {record.fileA.label}-
-        {record.fileB.label} 코드 비교 결과
+        &lt;{record.assignmentName}&gt; {record.fileA.label}-{bLabel} 코드 비교
+        결과
       </p>
     </div>
   );

--- a/src/features/Dashboard/History/SavedAnalysisItem.tsx
+++ b/src/features/Dashboard/History/SavedAnalysisItem.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { SavedAnalysisRecord } from './SavedAnalysisType';
 import Text from '@components/Text';
+import { formatDateTimeKST, formatPercent01 } from '@utils/format';
 
 interface Props {
   record: SavedAnalysisRecord;
@@ -17,8 +18,8 @@ const SavedAnalysisItem: React.FC<Props> = ({ record }) => {
           type="button"
           className="h-60 w-full cursor-pointer rounded-xl border border-gray-200 bg-white p-4 shadow-sm transition hover:shadow"
           onClick={() =>
-            navigate('/result', {
-              state: { fromSaved: true, recordId: record.id },
+            navigate('/record/detail', {
+              state: { record },
             })
           }
         >
@@ -33,42 +34,32 @@ const SavedAnalysisItem: React.FC<Props> = ({ record }) => {
     );
   }
 
+  // pair
+  const similarityText = formatPercent01(record.similarity ?? 0);
+  const aTime = formatDateTimeKST(record.fileA.submittedAt);
+  const bTime = formatDateTimeKST(record.fileB.submittedAt);
+
   return (
     <div className="flex flex-col items-center">
       <button
         type="button"
         className="h-60 w-full cursor-pointer rounded-xl border border-gray-200 bg-white p-4 shadow-sm transition hover:shadow"
-        onClick={() => {
-          if (!record.fileB) {
-            alert('비교 대상 파일 정보가 없습니다.');
-            return;
-          }
-          navigate(
-            `/compare/${String(record.fileA.id)}/${String(record.fileB.id)}`,
-            {
-              state: { fromSaved: true, recordId: record.id },
-            }
-          );
-        }}
+        onClick={() => navigate('/record/detail', { state: { record } })}
       >
-        {/* 유사도 */}
         <div className="text-center">
           <Text variant="body" weight="bold" className="text-xl text-red-600">
-            유사도 {record.similarity}%
+            유사도 {similarityText}
           </Text>
         </div>
 
-        {/* 파일/시간 */}
         <div className="mt-3 flex flex-col gap-2 text-gray-700">
           <div>
             <span className="font-medium">{record.fileA.label}</span>{' '}
-            <span className="text-blue-600">{record.fileA.submittedAt}</span>
+            <span className="text-blue-600">{aTime}</span>
           </div>
           <div>
-            <span className="font-medium">{record.fileB?.label ?? '-'}</span>{' '}
-            <span className="text-blue-600">
-              {record.fileB?.submittedAt ?? '-'}
-            </span>
+            <span className="font-medium">{record.fileB.label}</span>{' '}
+            <span className="text-blue-600">{bTime}</span>
           </div>
         </div>
       </button>

--- a/src/features/Dashboard/History/SavedAnalysisItem.tsx
+++ b/src/features/Dashboard/History/SavedAnalysisItem.tsx
@@ -17,11 +17,7 @@ const SavedAnalysisItem: React.FC<Props> = ({ record }) => {
         <button
           type="button"
           className="h-60 w-full cursor-pointer rounded-xl border border-gray-200 bg-white p-4 shadow-sm transition hover:shadow"
-          onClick={() =>
-            navigate('/record/detail', {
-              state: { record },
-            })
-          }
+          onClick={() => navigate(`/record/${record.id}`)}
         >
           <div className="flex h-full w-full items-center justify-center rounded bg-gray-50 text-gray-400 ring-1 ring-gray-100">
             네트워크 토폴로지 미리보기
@@ -44,7 +40,7 @@ const SavedAnalysisItem: React.FC<Props> = ({ record }) => {
       <button
         type="button"
         className="h-60 w-full cursor-pointer rounded-xl border border-gray-200 bg-white p-4 shadow-sm transition hover:shadow"
-        onClick={() => navigate('/record/detail', { state: { record } })}
+        onClick={() => navigate(`/record/${record.id}`)}
       >
         <div className="text-center">
           <Text variant="body" weight="bold" className="text-xl text-red-600">

--- a/src/features/Dashboard/History/SavedAnalysisItem.tsx
+++ b/src/features/Dashboard/History/SavedAnalysisItem.tsx
@@ -17,7 +17,7 @@ const SavedAnalysisItem: React.FC<Props> = ({ record }) => {
         <button
           type="button"
           className="h-60 w-full cursor-pointer rounded-xl border border-gray-200 bg-white p-4 shadow-sm transition hover:shadow"
-          onClick={() => navigate(`/record/${record.id}`)}
+          onClick={() => navigate(`/result?week=${record.week}`)}
         >
           <div className="flex h-full w-full items-center justify-center rounded bg-gray-50 text-gray-400 ring-1 ring-gray-100">
             네트워크 토폴로지 미리보기

--- a/src/features/Dashboard/History/SavedAnalysisItem.tsx
+++ b/src/features/Dashboard/History/SavedAnalysisItem.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { SavedAnalysisRecord } from './SavedAnalysisType';
 import Text from '@components/Text';
 import { formatDateTimeKST, formatPercent01 } from '@utils/format';
+import { useSubjectStore } from '@stores/useSubjectStore';
 
 interface Props {
   record: SavedAnalysisRecord;
@@ -10,6 +11,8 @@ interface Props {
 
 const SavedAnalysisItem: React.FC<Props> = ({ record }) => {
   const navigate = useNavigate();
+  const { selectedSubject } = useSubjectStore();
+  const subjectId = selectedSubject ? String(selectedSubject.id) : undefined;
 
   if (record.type === 'group') {
     return (
@@ -17,7 +20,10 @@ const SavedAnalysisItem: React.FC<Props> = ({ record }) => {
         <button
           type="button"
           className="h-60 w-full cursor-pointer rounded-xl border border-gray-200 bg-white p-4 shadow-sm transition hover:shadow"
-          onClick={() => navigate(`/result?week=${record.week}`)}
+          onClick={() => {
+            if (!subjectId) return alert('과목을 먼저 선택해 주세요.');
+            navigate(`/subjects/${subjectId}/record/${record.id}`);
+          }}
         >
           <div className="flex h-full w-full items-center justify-center rounded bg-gray-50 text-gray-400 ring-1 ring-gray-100">
             네트워크 토폴로지 미리보기
@@ -40,7 +46,10 @@ const SavedAnalysisItem: React.FC<Props> = ({ record }) => {
       <button
         type="button"
         className="h-60 w-full cursor-pointer rounded-xl border border-gray-200 bg-white p-4 shadow-sm transition hover:shadow"
-        onClick={() => navigate(`/record/${record.id}`)}
+        onClick={() => {
+          if (!subjectId) return alert('과목을 먼저 선택해 주세요.');
+          navigate(`/subjects/${subjectId}/record/${record.id}`);
+        }}
       >
         <div className="text-center">
           <Text variant="body" weight="bold" className="text-xl text-red-600">

--- a/src/features/Dashboard/History/SavedAnalysisSection.tsx
+++ b/src/features/Dashboard/History/SavedAnalysisSection.tsx
@@ -8,6 +8,12 @@ import { ErrorState, LoadingSkeleton } from '@components/LoadingState';
 
 type SortOption = 'latest' | 'similarity';
 
+const clamp01 = (v: unknown) => {
+  const n = Number(v);
+  if (!Number.isFinite(n)) return 0;
+  return Math.min(1, Math.max(0, n));
+};
+
 const SavedAnalysisSection: React.FC = () => {
   const [sortOption, setSortOption] = useState<SortOption>('latest');
   const [search, setSearch] = useState('');
@@ -58,8 +64,8 @@ const SavedAnalysisSection: React.FC = () => {
           assignmentName: selectedSubject!.name,
           week,
           savedAt,
-          similarity: typeof d.value === 'number' ? d.value : 0,
-          width: typeof d.width === 'number' ? d.width : 0,
+          similarity: clamp01(Number(d.value)),
+          width: Number.isFinite(Number(d.width)) ? Number(d.width) : 0,
           fileA: {
             id: fromId,
             label: nameMap.get(fromId) ?? fromId,

--- a/src/features/Dashboard/History/SavedAnalysisSection.tsx
+++ b/src/features/Dashboard/History/SavedAnalysisSection.tsx
@@ -1,29 +1,95 @@
 import React, { useMemo, useState } from 'react';
 import Text from '@components/Text';
-import { savedAnalysisRecords } from './SavedAnalysisDummy';
 import { SavedAnalysisRecord } from './SavedAnalysisType';
 import SavedAnalysisItem from './SavedAnalysisItem';
+import { useSubjectStore } from '@stores/useSubjectStore';
+import { useRecord } from '@hooks/useRecord';
+import { ErrorState, LoadingSkeleton } from '@components/LoadingState';
 
 type SortOption = 'latest' | 'similarity';
 
 const SavedAnalysisSection: React.FC = () => {
   const [sortOption, setSortOption] = useState<SortOption>('latest');
   const [search, setSearch] = useState('');
+  const { selectedSubject } = useSubjectStore();
+
+  const subjectIdNum = Number(selectedSubject?.id);
+  const hasSubject = !!selectedSubject && Number.isFinite(subjectIdNum);
+
+  const { data, isLoading, isError } = useRecord(
+    hasSubject ? subjectIdNum : undefined
+  );
+
+  // 응답 -> 화면 모델 어댑트
+  const records: SavedAnalysisRecord[] = useMemo(() => {
+    const msg = data;
+    if (!msg || !hasSubject) return [];
+
+    const nameMap = new Map<string, string>();
+    for (const n of msg.nodes ?? []) {
+      nameMap.set(String(n.id), n.label ?? '');
+    }
+
+    const list: SavedAnalysisRecord[] = [];
+    const dupCounter = new Map<string, number>();
+
+    for (const e of msg.edges ?? []) {
+      const week = Number(e.week) || 0;
+
+      for (const d of e.data ?? []) {
+        const fromId = String(d.from);
+        const toId = String(d.to);
+        const [a, b] = [fromId, toId].sort();
+        const submittedFrom = d.submittedFrom ?? '';
+        const submittedTo = d.submittedTo ?? '';
+        const baseId = `${week}__${a}-${b}__${submittedFrom}__${submittedTo}`;
+
+        const next = (dupCounter.get(baseId) ?? 0) + 1;
+        dupCounter.set(baseId, next);
+        const uniqueId = next === 1 ? baseId : `${baseId}__${next}`;
+
+        const savedAt =
+          submittedTo || submittedFrom || new Date().toISOString();
+
+        list.push({
+          id: uniqueId,
+          subjectId: subjectIdNum,
+          type: 'pair',
+          assignmentName: selectedSubject!.name,
+          week,
+          savedAt,
+          similarity: typeof d.value === 'number' ? d.value : 0,
+          width: typeof d.width === 'number' ? d.width : 0,
+          fileA: {
+            id: fromId,
+            label: nameMap.get(fromId) ?? fromId,
+            submittedAt: d.submittedFrom ?? savedAt,
+          },
+          fileB: {
+            id: toId,
+            label: nameMap.get(toId) ?? toId,
+            submittedAt: d.submittedTo ?? savedAt,
+          },
+        });
+      }
+    }
+    return list;
+  }, [data, hasSubject, selectedSubject, subjectIdNum]);
 
   // 정렬
   const sorted = useMemo(() => {
-    const list = [...savedAnalysisRecords];
+    const list = [...records];
     if (sortOption === 'similarity') {
       return list.sort((a, b) => {
         if (a.type !== 'pair') return 1;
         if (b.type !== 'pair') return -1;
-        return b.similarity - a.similarity;
+        return (b.similarity ?? 0) - (a.similarity ?? 0);
       });
     }
     return list.sort(
       (a, b) => new Date(b.savedAt).getTime() - new Date(a.savedAt).getTime()
     );
-  }, [sortOption]);
+  }, [records, sortOption]);
 
   // 검색
   const filtered = useMemo(() => {
@@ -31,7 +97,7 @@ const SavedAnalysisSection: React.FC = () => {
     if (!q) return sorted;
     return sorted.filter((r) => {
       const base =
-        `${r.assignmentName} ${'fileA' in r ? r.fileA.label : ''} ${'fileB' in r ? r.fileB.label : ''} ${r.week}주차 ${r.week}`.toLowerCase();
+        `${r.assignmentName} ${'fileA' in r ? r.fileA.label : ''} ${'fileB' in r ? r.fileB.label : ''} ${r.week}주차`.toLowerCase();
       return base.includes(q);
     });
   }, [sorted, search]);
@@ -45,6 +111,10 @@ const SavedAnalysisSection: React.FC = () => {
     });
     return Array.from(map.entries()).sort((a, b) => a[0] - b[0]);
   }, [filtered]);
+
+  if (!hasSubject) return null;
+  if (isLoading) return <LoadingSkeleton />;
+  if (isError || !data) return <ErrorState />;
 
   return (
     <section className="mt-10">
@@ -95,13 +165,13 @@ const SavedAnalysisSection: React.FC = () => {
 
       {/* 목록 */}
       <div className="space-y-10">
-        {groupedByWeek.map(([week, records]) => (
+        {groupedByWeek.map(([week, items]) => (
           <div key={week}>
             <div className="rounded-md bg-blue-50 py-2 text-center text-sm font-semibold text-blue-700 ring-1 ring-blue-100">
               {week}주차
             </div>
             <div className="mt-4 grid grid-cols-1 gap-6 sm:grid-cols-2">
-              {records.map((r) => (
+              {items.map((r) => (
                 <SavedAnalysisItem key={r.id} record={r} />
               ))}
             </div>

--- a/src/features/Dashboard/History/SavedAnalysisType.ts
+++ b/src/features/Dashboard/History/SavedAnalysisType.ts
@@ -2,6 +2,7 @@ export type AnalysisType = 'group' | 'pair';
 
 export interface BaseAnalysisRecord {
   id: string;
+  subjectId: number;
   assignmentName: string;
   week: number;
   type: AnalysisType;
@@ -25,6 +26,7 @@ export interface PairAnalysisRecord extends BaseAnalysisRecord {
     submittedAt: string;
   };
   similarity: number;
+  width?: number;
 }
 
 export type SavedAnalysisRecord = GroupAnalysisRecord | PairAnalysisRecord;

--- a/src/features/Dashboard/History/SavedRecordDetailPage.tsx
+++ b/src/features/Dashboard/History/SavedRecordDetailPage.tsx
@@ -1,0 +1,207 @@
+import React, { useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import Layout from '@components/Layout';
+import Text from '@components/Text';
+import Button from '@components/Button';
+import { PairAnalysisRecord, SavedAnalysisRecord } from './SavedAnalysisType';
+import { useRecord } from '@hooks/useRecord';
+import SimilarityGraph from '@features/Result/SimilarityGraph';
+import type { FileNode, FileEdge } from 'types/similarity';
+import { formatDateTimeKST, formatPercent01 } from '@utils/format';
+import { ErrorState, LoadingSkeleton } from '@components/LoadingState';
+
+function isPair(r: SavedAnalysisRecord | undefined): r is PairAnalysisRecord {
+  return !!r && r.type === 'pair';
+}
+
+const SavedRecordDetailPage: React.FC = () => {
+  const nav = useNavigate();
+  const { state } = useLocation() as {
+    state?: { record?: SavedAnalysisRecord };
+  };
+  const rec = state?.record;
+
+  const subjectId = isPair(rec) ? rec.subjectId : undefined;
+  const { data, isLoading, isError } = useRecord(subjectId);
+
+  const { nodes, edges } = useMemo(() => {
+    if (!data || !isPair(rec))
+      return { nodes: [] as FileNode[], edges: [] as FileEdge[] };
+
+    const labelById = new Map<string, string>();
+    for (const n of data.nodes ?? [])
+      labelById.set(String(n.id), n.label ?? String(n.id));
+
+    const weekItem = (data.edges ?? []).find(
+      (e) => Number(e.week) === Number(rec.week)
+    );
+    const raw = weekItem?.data ?? [];
+
+    // 등장 id 수집 → nodes
+    const idSet = new Set<string>();
+    for (const d of raw) {
+      idSet.add(String(d.from));
+      idSet.add(String(d.to));
+    }
+    const nodes: FileNode[] = Array.from(idSet).map((id) => ({
+      id,
+      label: labelById.get(id) ?? id,
+      submittedAt: '',
+    }));
+
+    // 동일 페어 병합 (최대 유사도 선택)
+    const edgeMap = new Map<string, FileEdge>();
+    for (const d of raw) {
+      const a = String(d.from);
+      const b = String(d.to);
+      const [x, y] = a <= b ? [a, b] : [b, a]; // 정렬된 페어 키
+      const key = `${x}-${y}`;
+      const sim = Math.round((typeof d.value === 'number' ? d.value : 0) * 100);
+
+      const prev = edgeMap.get(key);
+      if (!prev || sim > prev.similarity) {
+        edgeMap.set(key, { from: x, to: y, similarity: sim });
+      }
+    }
+    const edges = Array.from(edgeMap.values());
+    return { nodes, edges };
+  }, [data, rec]);
+
+  const highlightedEdges = useMemo<FileEdge[]>(() => {
+    if (!isPair(rec)) return edges;
+    const a = String(rec.fileA.id);
+    const b = String(rec.fileB.id);
+    return edges.map((e) => {
+      const isSelectedPair =
+        (e.from === a && e.to === b) || (e.from === b && e.to === a);
+      return isSelectedPair
+        ? { ...e, similarity: Math.min(100, e.similarity + 3) }
+        : e;
+    });
+  }, [edges, rec]);
+
+  if (!isPair(rec)) {
+    return (
+      <Layout>
+        <div className="mx-auto max-w-3xl px-6 py-12">
+          <Text variant="h3" weight="bold" className="text-gray-900">
+            기록 정보를 찾을 수 없어요.
+          </Text>
+          <Button
+            className="mt-6"
+            text="뒤로가기"
+            variant="primary"
+            onClick={() => nav(-1)}
+          />
+        </div>
+      </Layout>
+    );
+  }
+
+  if (isLoading) return <LoadingSkeleton />;
+  if (isError || !data) return <ErrorState />;
+
+  const simText = formatPercent01(rec.similarity);
+  const aTime = formatDateTimeKST(rec.fileA.submittedAt);
+  const bTime = formatDateTimeKST(rec.fileB.submittedAt);
+
+  return (
+    <Layout>
+      <div className="mx-auto max-w-7xl px-6 py-8">
+        <div className="mb-3">
+          <Button text="← 뒤로" variant="ghost" onClick={() => nav(-1)} />
+        </div>
+
+        <div className="mb-6">
+          <Text variant="h2" weight="bold" className="text-gray-900">
+            저장된 분석 상세
+          </Text>
+          <Text variant="caption" color="muted" className="mt-1">
+            &lt;{rec.assignmentName}&gt; · {rec.week}주차
+          </Text>
+        </div>
+
+        {/* 요약 */}
+        <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div className="rounded-xl border border-blue-100 bg-blue-50 p-4">
+            <Text variant="caption" color="muted">
+              유사도(선택된 쌍)
+            </Text>
+            <Text variant="h3" weight="bold" className="mt-1 text-blue-700">
+              {simText}
+            </Text>
+          </div>
+          <div className="rounded-xl border border-blue-100 bg-blue-50 p-4">
+            <Text variant="caption" color="muted">
+              비교 학생
+            </Text>
+            <Text variant="body" className="mt-1 text-blue-700">
+              {rec.fileA.label} · {rec.fileB.label}
+            </Text>
+          </div>
+        </div>
+
+        {/* 제출 시간 */}
+        <div className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-2">
+          {[rec.fileA, rec.fileB].map((f, i) => (
+            <div
+              key={i}
+              className="rounded-xl border border-gray-200 bg-white p-5"
+            >
+              <Text variant="body" weight="bold" className="text-gray-900">
+                {i === 0 ? 'Student A' : 'Student B'}
+              </Text>
+              <div className="mt-2 text-gray-700">
+                <div className="flex items-center justify-between">
+                  <span className="font-medium">{f.label}</span>
+                  <span className="text-xs text-gray-400">ID: {f.id}</span>
+                </div>
+                <div className="mt-1 text-sm">
+                  제출 시간:{' '}
+                  <span className="text-blue-600">
+                    {i === 0 ? aTime : bTime}
+                  </span>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* 네트워크 토폴로지 */}
+        <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+          <div className="mb-3 flex items-center justify-between">
+            <Text variant="h3" weight="bold" className="text-gray-900">
+              해당 주차 네트워크 토폴로지
+            </Text>
+            <Text variant="caption" color="muted">
+              선택된 쌍은 강조되어 표시됩니다.
+            </Text>
+          </div>
+          <SimilarityGraph
+            nodes={nodes}
+            edges={highlightedEdges}
+            interactionOptions={{
+              zoomView: false,
+              dragView: false,
+              dragNodes: false,
+            }}
+          />
+        </div>
+
+        <div className="mt-8 flex flex-wrap gap-3 justify-end">
+          <Button
+            text="해당 두 파일 비교로 이동"
+            variant="primary"
+            onClick={() =>
+              nav(`/compare/${String(rec.fileA.id)}/${String(rec.fileB.id)}`, {
+                state: { fromSaved: true, recordId: rec.id },
+              })
+            }
+          />
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export default SavedRecordDetailPage;

--- a/src/features/Dashboard/History/SavedRecordDetailPage.tsx
+++ b/src/features/Dashboard/History/SavedRecordDetailPage.tsx
@@ -108,7 +108,8 @@ const SavedRecordDetailPage: React.FC = () => {
       const b = String(d.to);
       const [x, y] = a <= b ? [a, b] : [b, a];
       const key = `${x}-${y}`;
-      const sim = Math.round((typeof d.value === 'number' ? d.value : 0) * 100);
+      const ratio = Number.isFinite(Number(d.value)) ? Number(d.value) : 0;
+      const sim = Math.round(Math.max(0, Math.min(1, ratio)) * 100);
       const prev = edgeMap.get(key);
       if (!prev || sim > prev.similarity)
         edgeMap.set(key, { from: x, to: y, similarity: sim });

--- a/src/features/Dashboard/History/SavedRecordDetailPage.tsx
+++ b/src/features/Dashboard/History/SavedRecordDetailPage.tsx
@@ -43,18 +43,26 @@ const SavedRecordDetailPage: React.FC = () => {
       nameMap.set(String(n.id), n.label ?? String(n.id));
     }
 
+    // edges를 화면 모델로 변환 (목록과 동일한 ID 규칙 사용)
     const records: SavedAnalysisRecord[] = [];
+    const dupCounter = new Map<string, number>();
+
     for (const e of data.edges ?? []) {
       const week = Number(e.week) || 0;
       for (const d of e.data ?? []) {
         const fromId = String(d.from);
         const toId = String(d.to);
+        const submittedFrom = d.submittedFrom ?? '';
+        const submittedTo = d.submittedTo ?? '';
+        const baseId = `${week}__${[fromId, toId].sort().join('-')}__${submittedFrom}__${submittedTo}`;
+        const next = (dupCounter.get(baseId) ?? 0) + 1;
+        dupCounter.set(baseId, next);
+        const uniqueId = d.id ?? (next === 1 ? baseId : `${baseId}__${next}`);
         const savedAt =
-          d.submittedTo ?? d.submittedFrom ?? new Date().toISOString();
-        const id = d.id ?? `${week}-${fromId}-${toId}-${savedAt}`;
+          submittedTo || submittedFrom || new Date().toISOString();
 
         records.push({
-          id,
+          id: uniqueId,
           type: 'pair',
           assignmentName: subjectName,
           week,

--- a/src/features/Dashboard/History/SavedRecordDetailPage.tsx
+++ b/src/features/Dashboard/History/SavedRecordDetailPage.tsx
@@ -67,8 +67,9 @@ const SavedRecordDetailPage: React.FC = () => {
           assignmentName: subjectName,
           week,
           savedAt,
-          similarity: Math.round(
-            (typeof d.value === 'number' ? d.value : 0) * 100
+          similarity: Math.min(
+            1,
+            Math.max(0, Number.isFinite(Number(d.value)) ? Number(d.value) : 0)
           ),
           fileA: {
             id: fromId,

--- a/src/features/Dashboard/UserInfoHeader.tsx
+++ b/src/features/Dashboard/UserInfoHeader.tsx
@@ -28,7 +28,7 @@ const UserInfoHeader: React.FC = () => {
   return (
     <header className="relative mt-8">
       {/* 상단 우측: 비밀번호 변경 */}
-      <div className="absolute right-0 top-0">
+      <div className="absolute right-5 top-5">
         <Button text="비밀번호 변경하기" variant="secondary" size="sm" />
       </div>
 

--- a/src/features/Result/ResultPage.tsx
+++ b/src/features/Result/ResultPage.tsx
@@ -95,7 +95,7 @@ const ResultPage: React.FC = () => {
   // 1) 스토어에 저장·비교에 쓰는 원본 데이터(스토어 타입으로 정규화)
   const fileDataList: StoreFileData[] = useMemo(
     () => normalizeToStoreData(dummyFiles as ReadonlyArray<DummyLike>),
-    [dummyFiles]
+    []
   );
 
   // 2) 그래프 전용 노드 파생

--- a/src/features/Result/SimilarityGraph.tsx
+++ b/src/features/Result/SimilarityGraph.tsx
@@ -96,20 +96,20 @@ const SimilarityGraph: React.FC<Props> = ({
       }))
     );
 
-    const {
-      dragNodes = false,
-      zoomView = false,
-      dragView = false,
-    } = interactionOptions ?? {};
+    // const {
+    //   dragNodes = false,
+    //   zoomView = false,
+    //   dragView = false,
+    // } = interactionOptions ?? {};
 
     const network = new Network(
       containerRef.current,
       { nodes: visNodes, edges: visEdges },
       {
         physics: {
-          enabled: true,
+          enabled: true, // 1) 처음엔 켜서 레이아웃 잡고
           solver: 'forceAtlas2Based',
-          stabilization: { iterations: 400 },
+          stabilization: { iterations: 300 },
           forceAtlas2Based: {
             gravitationalConstant: -50,
             centralGravity: 0.02,
@@ -119,6 +119,7 @@ const SimilarityGraph: React.FC<Props> = ({
             avoidOverlap: 1,
           },
         },
+        layout: { improvedLayout: true, randomSeed: 42 }, // 재랜더링 일관성
         nodes: {
           shape: 'dot',
           size: 20,
@@ -136,22 +137,29 @@ const SimilarityGraph: React.FC<Props> = ({
             strokeColor: '#1e293b',
           },
           borderWidth: 2,
+          physics: false, // 개별 노드는 물리 영향 받지 않게(흔들림 감소)
         },
         edges: {
           selectionWidth: 2,
           hoverWidth: 0,
           arrows: { to: { enabled: false } },
+          smooth: { enabled: true, type: 'dynamic', roundness: 0.5 },
         },
         interaction: {
           hover: true,
           tooltipDelay: 120,
-          zoomView,
-          dragView,
-          dragNodes,
+          zoomView: interactionOptions?.zoomView ?? false,
+          dragView: interactionOptions?.dragView ?? false,
+          dragNodes: interactionOptions?.dragNodes ?? false,
           selectable: true,
         },
       }
     );
+
+    // 안정화가 끝나면 물리 끄기 → 더 이상 안 흔들림
+    network.once('stabilized', () => {
+      network.setOptions({ physics: { enabled: false } });
+    });
 
     networkRef.current = network;
 

--- a/src/features/Result/SimilarityGraph.tsx
+++ b/src/features/Result/SimilarityGraph.tsx
@@ -137,7 +137,7 @@ const SimilarityGraph: React.FC<Props> = ({
             strokeColor: '#1e293b',
           },
           borderWidth: 2,
-          physics: false, // 개별 노드는 물리 영향 받지 않게(흔들림 감소)
+          // physics: false, // 개별 노드는 물리 영향 받지 않게(흔들림 감소)
         },
         edges: {
           selectionWidth: 2,

--- a/src/features/Result/SimilarityGraph.tsx
+++ b/src/features/Result/SimilarityGraph.tsx
@@ -15,11 +15,27 @@ interface Props {
   };
 }
 
+const brand = {
+  nodeBg: '#2563eb', // tailwind blue-600
+  nodeBorder: '#1d4ed8', // blue-700
+  edgeLow: '#94a3b8', // slate-400
+  edgeMid: '#3b82f6', // blue-500
+  edgeHigh: '#f59e0b', // amber-500
+  edgeVery: '#ef4444', // red-500
+  label: '#334155', // slate-700
+};
+
 const edgeColor = (s: number) =>
-  s >= 90 ? '#ef4444' : s >= 75 ? '#f59e0b' : s >= 60 ? '#3b82f6' : '#94a3b8';
+  s >= 90
+    ? brand.edgeVery
+    : s >= 75
+      ? brand.edgeHigh
+      : s >= 60
+        ? brand.edgeMid
+        : brand.edgeLow;
 
 const edgeWidth = (s: number) =>
-  s >= 90 ? 8 : s >= 75 ? 6 : s >= 60 ? 4 : s >= 40 ? 2 : 1;
+  s >= 90 ? 10 : s >= 75 ? 7 : s >= 60 ? 5 : s >= 40 ? 3 : 2;
 
 const SimilarityGraph: React.FC<Props> = ({
   nodes,
@@ -35,17 +51,29 @@ const SimilarityGraph: React.FC<Props> = ({
   useEffect(() => {
     if (!containerRef.current) return;
 
+    // 동일 페어 중복 제거
+    const dedupEdges = (() => {
+      const m = new Map<string, FileEdge>();
+      for (const e of edges) {
+        const [x, y] = e.from <= e.to ? [e.from, e.to] : [e.to, e.from];
+        const k = `${x}-${y}`;
+        const prev = m.get(k);
+        if (!prev || e.similarity > prev.similarity)
+          m.set(k, { ...e, from: x, to: y });
+      }
+      return Array.from(m.values());
+    })();
+
     const visNodes = new DataSet(
       nodes.map((n) => ({
         id: n.id,
         label: n.label,
-        title: undefined, // 기본 툴팁 제거
-        fixed: { x: true, y: true },
+        title: undefined,
       }))
     );
 
     const visEdges = new DataSet(
-      edges.map((e) => ({
+      dedupEdges.map((e) => ({
         id: `${e.from}-${e.to}`,
         from: e.from,
         to: e.to,
@@ -56,7 +84,15 @@ const SimilarityGraph: React.FC<Props> = ({
           hover: edgeColor(e.similarity),
           highlight: edgeColor(e.similarity),
         },
-        font: { align: 'middle', color: '#475569', size: 12 },
+        font: {
+          align: 'middle',
+          color: brand.label,
+          size: 14,
+          face: 'Inter, ui-sans-serif',
+          strokeWidth: 2,
+          strokeColor: '#ffffff',
+        },
+        smooth: { enabled: true, type: 'dynamic', roundness: 0.5 },
       }))
     );
 
@@ -70,16 +106,42 @@ const SimilarityGraph: React.FC<Props> = ({
       containerRef.current,
       { nodes: visNodes, edges: visEdges },
       {
-        physics: { enabled: false },
-        layout: { randomSeed: 42 },
+        physics: {
+          enabled: true,
+          solver: 'forceAtlas2Based',
+          stabilization: { iterations: 400 },
+          forceAtlas2Based: {
+            gravitationalConstant: -50,
+            centralGravity: 0.02,
+            springLength: 200,
+            springConstant: 0.04,
+            damping: 0.4,
+            avoidOverlap: 1,
+          },
+        },
         nodes: {
           shape: 'dot',
-          size: 18,
-          fixed: true,
-          physics: false,
-          color: { background: '#0ea5e9', border: '#0284c7' },
+          size: 20,
+          color: {
+            background: brand.nodeBg,
+            border: brand.nodeBorder,
+            highlight: brand.nodeBg,
+            hover: brand.nodeBg,
+          },
+          font: {
+            color: '#ffffff',
+            size: 16,
+            face: 'Inter, ui-sans-serif',
+            strokeWidth: 3,
+            strokeColor: '#1e293b',
+          },
+          borderWidth: 2,
         },
-        edges: { smooth: true },
+        edges: {
+          selectionWidth: 2,
+          hoverWidth: 0,
+          arrows: { to: { enabled: false } },
+        },
         interaction: {
           hover: true,
           tooltipDelay: 120,
@@ -93,7 +155,7 @@ const SimilarityGraph: React.FC<Props> = ({
 
     networkRef.current = network;
 
-    // Hover select 효과 추가(가독성↑)
+    // 이벤트 연결
     network.on('hoverNode', (params) => {
       network.selectNodes([params.node]);
       const node = nodes.find((n) => n.id === params.node);
@@ -104,7 +166,7 @@ const SimilarityGraph: React.FC<Props> = ({
     network.on('hoverEdge', (params) => {
       network.selectEdges([params.edge]);
       const [fromId, toId] = String(params.edge).split('-');
-      const edge = edges.find(
+      const edge = dedupEdges.find(
         (e) =>
           (e.from === fromId && e.to === toId) ||
           (e.from === toId && e.to === fromId)
@@ -116,7 +178,7 @@ const SimilarityGraph: React.FC<Props> = ({
     network.on('click', (params) => {
       if (params.edges.length === 0) return;
       const [fromId, toId] = String(params.edges[0]).split('-');
-      const edge = edges.find(
+      const edge = dedupEdges.find(
         (e) =>
           (e.from === fromId && e.to === toId) ||
           (e.from === toId && e.to === fromId)
@@ -127,7 +189,7 @@ const SimilarityGraph: React.FC<Props> = ({
     return () => network.destroy();
   }, [nodes, edges, onNodeHover, onEdgeHover, onEdgeClick, interactionOptions]);
 
-  return <div ref={containerRef} className="h-[520px] w-full" />;
+  return <div ref={containerRef} className="h-[560px] w-full" />;
 };
 
 export default SimilarityGraph;

--- a/src/hooks/useAccumulatedTopology.ts
+++ b/src/hooks/useAccumulatedTopology.ts
@@ -1,15 +1,12 @@
 import { fetchAccumulatedTopology } from '@services/dashboard';
+import { AccumulatedResponseData } from '@typings/dashboard';
 import { useQuery } from 'react-query';
-import { AccumulatedApiResponse } from 'types/dashboard';
 
-export const useAccumulatedTopology = (
-  assignmentName: string,
-  token: string
-) => {
-  return useQuery<AccumulatedApiResponse>({
-    queryKey: ['accumulatedTopology', assignmentName],
-    queryFn: () => fetchAccumulatedTopology(assignmentName, token),
-    enabled: !!assignmentName && !!token,
+export const useAccumulatedTopology = (subjectId: number | undefined) => {
+  return useQuery<AccumulatedResponseData>({
+    queryKey: ['accumulatedTopology', subjectId],
+    queryFn: () => fetchAccumulatedTopology(subjectId!),
+    enabled: !!subjectId,
     staleTime: 1000 * 60 * 5,
   });
 };

--- a/src/hooks/useMainDashboard.ts
+++ b/src/hooks/useMainDashboard.ts
@@ -1,12 +1,12 @@
 import { fetchMain } from '@services/dashboard';
 import { useQuery } from 'react-query';
-import { MainApiResponse } from 'types/dashboard';
+import { MainResponseData } from 'types/dashboard';
 
-export const useMainDashboard = (token: string) => {
-  return useQuery<MainApiResponse>({
+export const useMainDashboard = () => {
+  return useQuery<MainResponseData>({
     queryKey: ['mainDashboard'],
-    queryFn: () => fetchMain(token),
-    enabled: !!token,
+    queryFn: fetchMain,
     staleTime: 1000 * 60 * 10,
+    refetchOnWindowFocus: false,
   });
 };

--- a/src/hooks/useRecord.ts
+++ b/src/hooks/useRecord.ts
@@ -1,12 +1,13 @@
 import { fetchRecord } from '@services/dashboard';
+import { RecordResponseData } from '@typings/dashboard';
 import { useQuery } from 'react-query';
-import { RecordApiResponse } from 'types/dashboard';
 
-export const useRecord = (token: string) => {
-  return useQuery<RecordApiResponse>({
-    queryKey: ['record', token],
-    queryFn: () => fetchRecord(token),
-    enabled: !!token,
+export const useRecord = (subjectId?: number) => {
+  return useQuery<RecordResponseData>({
+    queryKey: ['record', subjectId],
+    queryFn: () => fetchRecord(subjectId!),
+    enabled: !!subjectId,
     staleTime: 1000 * 60 * 5,
+    refetchOnWindowFocus: false,
   });
 };

--- a/src/mocks/accumulatedMock.ts
+++ b/src/mocks/accumulatedMock.ts
@@ -1,31 +1,18 @@
-// import { AccumulatedApiResponse } from 'types/dashboard';
-
-// export const accumulatedMock: AccumulatedApiResponse = {
-//   status: 200,
-//   success: true,
-//   message: {
-//     nodes: [
-//       { id: '21000000', label: 'Student A' },
-//       { id: '21000001', label: 'Student B' },
-//       { id: '21000002', label: 'Student C' },
-//     ],
-//     edges: [
-//       {
-//         id: '21000000-21000001',
-//         from: '21000000',
-//         to: '21000001',
-//         count: 3,
-//         value: 0.85,
-//         width: 8.5,
-//       },
-//       {
-//         id: '21000001-21000002',
-//         from: '21000001',
-//         to: '21000002',
-//         count: 2,
-//         value: 0.6,
-//         width: 6.0,
-//       },
-//     ],
-//   },
-// };
+export const accumulatedMock = {
+  nodes: [
+    {
+      id: 9007199254740991,
+      label: 'string',
+    },
+  ],
+  edges: [
+    {
+      id: 'string',
+      from: 9007199254740991,
+      to: 9007199254740991,
+      count: 1073741824,
+      value: 0.1,
+      width: 0.1,
+    },
+  ],
+};

--- a/src/mocks/accumulatedMock.ts
+++ b/src/mocks/accumulatedMock.ts
@@ -1,31 +1,31 @@
-import { AccumulatedApiResponse } from 'types/dashboard';
+// import { AccumulatedApiResponse } from 'types/dashboard';
 
-export const accumulatedMock: AccumulatedApiResponse = {
-  status: 200,
-  success: true,
-  message: {
-    nodes: [
-      { id: '21000000', label: 'Student A' },
-      { id: '21000001', label: 'Student B' },
-      { id: '21000002', label: 'Student C' },
-    ],
-    edges: [
-      {
-        id: '21000000-21000001',
-        from: '21000000',
-        to: '21000001',
-        count: 3,
-        value: 0.85,
-        width: 8.5,
-      },
-      {
-        id: '21000001-21000002',
-        from: '21000001',
-        to: '21000002',
-        count: 2,
-        value: 0.6,
-        width: 6.0,
-      },
-    ],
-  },
-};
+// export const accumulatedMock: AccumulatedApiResponse = {
+//   status: 200,
+//   success: true,
+//   message: {
+//     nodes: [
+//       { id: '21000000', label: 'Student A' },
+//       { id: '21000001', label: 'Student B' },
+//       { id: '21000002', label: 'Student C' },
+//     ],
+//     edges: [
+//       {
+//         id: '21000000-21000001',
+//         from: '21000000',
+//         to: '21000001',
+//         count: 3,
+//         value: 0.85,
+//         width: 8.5,
+//       },
+//       {
+//         id: '21000001-21000002',
+//         from: '21000001',
+//         to: '21000002',
+//         count: 2,
+//         value: 0.6,
+//         width: 6.0,
+//       },
+//     ],
+//   },
+// };

--- a/src/mocks/mainMock.ts
+++ b/src/mocks/mainMock.ts
@@ -1,23 +1,13 @@
-// import { MainApiResponse } from 'types/dashboard';
-
-// export const mainMock: MainApiResponse = {
-//   status: 200,
-//   success: true,
-//   message: {
-//     user: {
-//       userId: 123,
-//       userName: '사용자',
-//     },
-//     testCount: 5,
-//     subjects: [
-//       {
-//         subjectId: 1,
-//         subjectName: '프로그래밍 입문',
-//       },
-//       {
-//         subjectId: 2,
-//         subjectName: '공학 수학',
-//       },
-//     ],
-//   },
-// };
+export const mainMock = {
+  user: {
+    userId: 'string',
+    name: 'string',
+  },
+  testCount: 1073741824,
+  subjects: [
+    {
+      subjectId: 9007199254740991,
+      subjectName: 'string',
+    },
+  ],
+};

--- a/src/mocks/mainMock.ts
+++ b/src/mocks/mainMock.ts
@@ -1,23 +1,23 @@
-import { MainApiResponse } from 'types/dashboard';
+// import { MainApiResponse } from 'types/dashboard';
 
-export const mainMock: MainApiResponse = {
-  status: 200,
-  success: true,
-  message: {
-    user: {
-      userId: 123,
-      userName: '사용자',
-    },
-    testCount: 5,
-    subjects: [
-      {
-        subjectId: 1,
-        subjectName: '프로그래밍 입문',
-      },
-      {
-        subjectId: 2,
-        subjectName: '공학 수학',
-      },
-    ],
-  },
-};
+// export const mainMock: MainApiResponse = {
+//   status: 200,
+//   success: true,
+//   message: {
+//     user: {
+//       userId: 123,
+//       userName: '사용자',
+//     },
+//     testCount: 5,
+//     subjects: [
+//       {
+//         subjectId: 1,
+//         subjectName: '프로그래밍 입문',
+//       },
+//       {
+//         subjectId: 2,
+//         subjectName: '공학 수학',
+//       },
+//     ],
+//   },
+// };

--- a/src/mocks/recordMock.ts
+++ b/src/mocks/recordMock.ts
@@ -1,73 +1,73 @@
-import { RecordApiResponse } from 'types/dashboard';
+// import { RecordApiResponse } from 'types/dashboard';
 
-export const recordMock: RecordApiResponse = {
-  status: 200,
-  success: true,
-  message: {
-    nodes: [
-      { id: '21000000', label: 'Student A', submittedAt: '2025-04-11 14:00' },
-      { id: '21000001', label: 'Student B', submittedAt: '2025-04-11 15:00' },
-      { id: '21000002', label: 'Student C', submittedAt: '2025-04-11 15:00' },
-    ],
-    edges: [
-      {
-        week: 1,
-        weekData: [
-          {
-            id: '21000000-21000001',
-            from: '21000000',
-            to: '21000001',
-            value: 0.85,
-            width: 8.5,
-            histories: [
-              {
-                submittedFrom: '2025-04-11 14:00',
-                submittedTo: '2025-04-11 15:00',
-                similarity: 0.88,
-              },
-              {
-                submittedFrom: '2025-04-18 13:40',
-                submittedTo: '2025-04-18 13:45',
-                similarity: 0.83,
-              },
-              {
-                submittedFrom: '2025-04-25 12:30',
-                submittedTo: '2025-04-25 12:31',
-                similarity: 0.84,
-              },
-            ],
-          },
-        ],
-      },
-      {
-        week: 2,
-        weekData: [
-          {
-            id: '21000000-21000001',
-            from: '21000000',
-            to: '21000001',
-            value: 0.85,
-            width: 8.5,
-            histories: [
-              {
-                submittedFrom: '2025-04-11 14:00',
-                submittedTo: '2025-04-11 15:00',
-                similarity: 0.88,
-              },
-              {
-                submittedFrom: '2025-04-18 13:40',
-                submittedTo: '2025-04-18 13:45',
-                similarity: 0.83,
-              },
-              {
-                submittedFrom: '2025-04-25 12:30',
-                submittedTo: '2025-04-25 12:31',
-                similarity: 0.84,
-              },
-            ],
-          },
-        ],
-      },
-    ],
-  },
-};
+// export const recordMock: RecordApiResponse = {
+//   status: 200,
+//   success: true,
+//   message: {
+//     nodes: [
+//       { id: '21000000', label: 'Student A', submittedAt: '2025-04-11 14:00' },
+//       { id: '21000001', label: 'Student B', submittedAt: '2025-04-11 15:00' },
+//       { id: '21000002', label: 'Student C', submittedAt: '2025-04-11 15:00' },
+//     ],
+//     edges: [
+//       {
+//         week: 1,
+//         weekData: [
+//           {
+//             id: '21000000-21000001',
+//             from: '21000000',
+//             to: '21000001',
+//             value: 0.85,
+//             width: 8.5,
+//             histories: [
+//               {
+//                 submittedFrom: '2025-04-11 14:00',
+//                 submittedTo: '2025-04-11 15:00',
+//                 similarity: 0.88,
+//               },
+//               {
+//                 submittedFrom: '2025-04-18 13:40',
+//                 submittedTo: '2025-04-18 13:45',
+//                 similarity: 0.83,
+//               },
+//               {
+//                 submittedFrom: '2025-04-25 12:30',
+//                 submittedTo: '2025-04-25 12:31',
+//                 similarity: 0.84,
+//               },
+//             ],
+//           },
+//         ],
+//       },
+//       {
+//         week: 2,
+//         weekData: [
+//           {
+//             id: '21000000-21000001',
+//             from: '21000000',
+//             to: '21000001',
+//             value: 0.85,
+//             width: 8.5,
+//             histories: [
+//               {
+//                 submittedFrom: '2025-04-11 14:00',
+//                 submittedTo: '2025-04-11 15:00',
+//                 similarity: 0.88,
+//               },
+//               {
+//                 submittedFrom: '2025-04-18 13:40',
+//                 submittedTo: '2025-04-18 13:45',
+//                 similarity: 0.83,
+//               },
+//               {
+//                 submittedFrom: '2025-04-25 12:30',
+//                 submittedTo: '2025-04-25 12:31',
+//                 similarity: 0.84,
+//               },
+//             ],
+//           },
+//         ],
+//       },
+//     ],
+//   },
+// };

--- a/src/mocks/recordMock.ts
+++ b/src/mocks/recordMock.ts
@@ -1,73 +1,24 @@
-// import { RecordApiResponse } from 'types/dashboard';
-
-// export const recordMock: RecordApiResponse = {
-//   status: 200,
-//   success: true,
-//   message: {
-//     nodes: [
-//       { id: '21000000', label: 'Student A', submittedAt: '2025-04-11 14:00' },
-//       { id: '21000001', label: 'Student B', submittedAt: '2025-04-11 15:00' },
-//       { id: '21000002', label: 'Student C', submittedAt: '2025-04-11 15:00' },
-//     ],
-//     edges: [
-//       {
-//         week: 1,
-//         weekData: [
-//           {
-//             id: '21000000-21000001',
-//             from: '21000000',
-//             to: '21000001',
-//             value: 0.85,
-//             width: 8.5,
-//             histories: [
-//               {
-//                 submittedFrom: '2025-04-11 14:00',
-//                 submittedTo: '2025-04-11 15:00',
-//                 similarity: 0.88,
-//               },
-//               {
-//                 submittedFrom: '2025-04-18 13:40',
-//                 submittedTo: '2025-04-18 13:45',
-//                 similarity: 0.83,
-//               },
-//               {
-//                 submittedFrom: '2025-04-25 12:30',
-//                 submittedTo: '2025-04-25 12:31',
-//                 similarity: 0.84,
-//               },
-//             ],
-//           },
-//         ],
-//       },
-//       {
-//         week: 2,
-//         weekData: [
-//           {
-//             id: '21000000-21000001',
-//             from: '21000000',
-//             to: '21000001',
-//             value: 0.85,
-//             width: 8.5,
-//             histories: [
-//               {
-//                 submittedFrom: '2025-04-11 14:00',
-//                 submittedTo: '2025-04-11 15:00',
-//                 similarity: 0.88,
-//               },
-//               {
-//                 submittedFrom: '2025-04-18 13:40',
-//                 submittedTo: '2025-04-18 13:45',
-//                 similarity: 0.83,
-//               },
-//               {
-//                 submittedFrom: '2025-04-25 12:30',
-//                 submittedTo: '2025-04-25 12:31',
-//                 similarity: 0.84,
-//               },
-//             ],
-//           },
-//         ],
-//       },
-//     ],
-//   },
-// };
+export const recordMock = {
+  nodes: [
+    {
+      id: 9007199254740991,
+      label: 'string',
+    },
+  ],
+  edges: [
+    {
+      week: 9007199254740991,
+      data: [
+        {
+          id: 'string',
+          from: 9007199254740991,
+          to: 9007199254740991,
+          submittedFrom: '2025-09-08T08:00:54.024Z',
+          submittedTo: '2025-09-08T08:00:54.024Z',
+          value: 0.1,
+          width: 0.1,
+        },
+      ],
+    },
+  ],
+};

--- a/src/services/dashboard.ts
+++ b/src/services/dashboard.ts
@@ -1,5 +1,5 @@
 import {
-  AccumulatedApiResponse,
+  AccumulatedResponseData,
   MainResponseData,
   RecordResponseData,
 } from 'types/dashboard';
@@ -11,19 +11,17 @@ import { mainMock } from '@mocks/mainMock';
 /// 누적 네트워크 토폴로지
 
 export const fetchAccumulatedTopology = async (
-  assignmentName: string,
-  token: string
-): Promise<AccumulatedApiResponse> => {
+  subjectId: number
+): Promise<AccumulatedResponseData> => {
   if (import.meta.env.VITE_USE_MOCK === 'true') {
     await new Promise((r) => setTimeout(r, 300));
     return accumulatedMock;
   }
 
-  const response = await axiosInstance.get<AccumulatedApiResponse>(
+  const response = await axiosInstance.get<AccumulatedResponseData>(
     `/api/dashboard/accumulate`,
     {
-      params: { assignmentName },
-      headers: { Authorization: `Bearer ${token}` },
+      params: { subjectId },
     }
   );
   return response.data;

--- a/src/services/dashboard.ts
+++ b/src/services/dashboard.ts
@@ -1,6 +1,6 @@
 import {
   AccumulatedApiResponse,
-  MainApiResponse,
+  MainResponseData,
   RecordApiResponse,
 } from 'types/dashboard';
 import axiosInstance from './axiosInstance';
@@ -50,17 +50,13 @@ export const fetchRecord = async (
 
 /// 대시보드 메인
 
-export const fetchMain = async (token: string): Promise<MainApiResponse> => {
+export const fetchMain = async (): Promise<MainResponseData> => {
   if (import.meta.env.VITE_USE_MOCK === 'true') {
     await new Promise((r) => setTimeout(r, 300));
     return mainMock;
   }
 
-  const response = await axiosInstance.get<MainApiResponse>(
-    `/api/dashboard/main`,
-    {
-      headers: { Authorization: `Bearer ${token}` },
-    }
-  );
+  const response =
+    await axiosInstance.get<MainResponseData>(`/api/dashboard/main`);
   return response.data;
 };

--- a/src/services/dashboard.ts
+++ b/src/services/dashboard.ts
@@ -1,7 +1,7 @@
 import {
   AccumulatedApiResponse,
   MainResponseData,
-  RecordApiResponse,
+  RecordResponseData,
 } from 'types/dashboard';
 import axiosInstance from './axiosInstance';
 import { accumulatedMock } from '@mocks/accumulatedMock';
@@ -32,17 +32,17 @@ export const fetchAccumulatedTopology = async (
 /// 저장된 분석 기록
 
 export const fetchRecord = async (
-  token: string
-): Promise<RecordApiResponse> => {
+  subjectId: number
+): Promise<RecordResponseData> => {
   if (import.meta.env.VITE_USE_MOCK === 'true') {
     await new Promise((r) => setTimeout(r, 300));
     return recordMock;
   }
 
-  const response = await axiosInstance.get<RecordApiResponse>(
+  const response = await axiosInstance.get<RecordResponseData>(
     `/api/dashboard/record`,
     {
-      headers: { Authorization: `Bearer ${token}` },
+      params: { subjectId },
     }
   );
   return response.data;

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -28,40 +28,28 @@ export interface AccumulatedApiResponse {
 /// 저장된 분석 기록
 
 export interface RecordNode {
-  id: string;
+  id: number;
   label: string;
-  submittedAt: string; // 제출 시간
 }
 
-export interface RecordWeekHistory {
+export interface RecordWeekData {
+  id: string;
+  from: number;
+  to: number;
   submittedFrom: string;
   submittedTo: string;
-  similarity: number;
-}
-
-export interface RecordWeekEdge {
-  id: string;
-  from: string;
-  to: string;
   value: number;
   width: number;
-  histories: RecordWeekHistory[];
 }
 
 export interface RecordEdge {
   week: number;
-  weekData: RecordWeekEdge[];
+  data: RecordWeekData[];
 }
 
 export interface RecordResponseData {
   nodes: RecordNode[];
   edges: RecordEdge[];
-}
-
-export interface RecordApiResponse {
-  status: number;
-  success: boolean;
-  message: RecordResponseData;
 }
 
 /// 대시보드 메인

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -19,12 +19,6 @@ export interface AccumulatedResponseData {
   edges: AccumulatedEdge[];
 }
 
-export interface AccumulatedApiResponse {
-  status: number;
-  success: boolean;
-  message: AccumulatedResponseData;
-}
-
 /// 저장된 분석 기록
 
 export interface RecordNode {

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -67,8 +67,8 @@ export interface RecordApiResponse {
 /// 대시보드 메인
 
 export interface MainUser {
-  userId: number;
-  userName: string;
+  userId: string;
+  name: string;
 }
 
 export interface MainSubject {
@@ -80,10 +80,4 @@ export interface MainResponseData {
   user: MainUser;
   testCount: number; // 진행한 유사도 검사 횟수
   subjects: MainSubject[];
-}
-
-export interface MainApiResponse {
-  status: number;
-  success: boolean;
-  message: MainResponseData;
 }

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -1,14 +1,14 @@
 /// 누적 네트워크 토폴로지
 
 export interface AccumulatedNode {
-  id: string; // 학번
+  id: number; // 학번
   label: string; // 이름
 }
 
 export interface AccumulatedEdge {
   id: string; // fromId-toId 형식
-  from: string;
-  to: string;
+  from: number;
+  to: number;
   count: number; // 높은 유사도 누적 횟수
   value: number; // 평균 유사도
   width: number; // 시각화에 사용할 굵기 정보

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,18 @@
+export function formatPercent01(value: number, digits = 1) {
+  // value: 0~1 → "89.5%"
+  const pct = Math.max(0, Math.min(1, Number(value))) * 100;
+  return `${pct.toFixed(digits)}%`;
+}
+
+export function formatDateTimeKST(isoLike: string) {
+  const d = new Date(isoLike);
+  if (Number.isNaN(d.getTime())) return '-';
+  return new Intl.DateTimeFormat('ko-KR', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(d);
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -5,7 +5,16 @@ export function formatPercent01(value: number, digits = 1) {
 }
 
 export function formatDateTimeKST(isoLike: string) {
-  const d = new Date(isoLike);
+  if (!isoLike) return '-';
+  let s = String(isoLike).trim();
+  // "YYYY-MM-DD HH:mm" 형식이면 KST로 간주하여 타임존 명시
+  if (
+    /^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}/.test(s) &&
+    !/[Z+\\-]\\d{2}:?\\d{2}$/.test(s)
+  ) {
+    s = s.replace(' ', 'T') + '+09:00';
+  }
+  const d = new Date(s);
   if (Number.isNaN(d.getTime())) return '-';
   return new Intl.DateTimeFormat('ko-KR', {
     timeZone: 'Asia/Seoul',
@@ -14,5 +23,6 @@ export function formatDateTimeKST(isoLike: string) {
     day: '2-digit',
     hour: '2-digit',
     minute: '2-digit',
+    hour12: false,
   }).format(d);
 }


### PR DESCRIPTION
## 🔍 상세 내용

- 대시보드 메인 조회 / 누적 네트워크 토폴로지 조회 / 저장된 분석 기록 조회 API 연동
- 네트워크 토폴로지 UI 수정
- 저장된 분석 기록 아이템 상세 조회 페이지 별도 구현

## 📂 관련 이슈

- closed #33 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 저장된 분석 상세 페이지 추가 및 히스토리에서 과목별 개별 기록으로 바로 이동 가능
  - 앱 라우트에 저장된 기록 상세 뷰 경로 추가
- **개선**
  - 대시보드(메인·히스토리)와 누적 유사도 그래프가 선택한 과목 기준 실데이터로 동작
  - 사용자 헤더가 서버 데이터 기반 과목 목록 및 선택 토글 지원
  - 그래프 테마·레이아웃·중복 간선 처리로 시각 가독성 향상
  - 히스토리 항목의 유사도·제출시간 표시 포맷 개선
- **신뢰성**
  - 공통 로딩 스켈레톤 및 에러 상태 UI 추가
- **버그 수정**
  - 히스토리 검색 문자열의 주차 중복 표기 제거
<!-- end of auto-generated comment: release notes by coderabbit.ai -->