### PR TITLE
FEAT: result 관련 API 연동

### DIFF
--- a/src/features/Compare/ComparePage.tsx
+++ b/src/features/Compare/ComparePage.tsx
@@ -174,16 +174,24 @@ const ComparePage: React.FC = () => {
     if (!isLoggedIn) {
       navigate('/login', { state: { from: 'result' } });
     } else {
+      const extractFileName = (label: string) =>
+        label.match(/\((.*?)\)\s*$/)?.[1] ?? '';
+      const fileNameA =
+        compareData?.student1.fileName ?? extractFileName(selectedFileA!.label);
+      const fileNameB =
+        compareData?.student2.fileName ?? extractFileName(selectedFileB!.label);
       navigate('/decision', {
         state: {
           fileA: {
             id: selectedFileA!.id,
             label: selectedFileA!.label,
+            fileName: fileNameA,
             submittedAt: selectedFileA!.submittedAt,
           },
           fileB: {
             id: selectedFileB!.id,
             label: selectedFileB!.label,
+            fileName: fileNameB,
             submittedAt: selectedFileB!.submittedAt,
           },
           studentFromId: selectedFileA!.id,

--- a/src/features/Compare/ComparePage.tsx
+++ b/src/features/Compare/ComparePage.tsx
@@ -9,6 +9,8 @@ import { FiArrowLeft } from 'react-icons/fi';
 import { useSelectedFileStore } from '@stores/useSelectedFileStore';
 import { useSavedRecordStore } from '@stores/useSavedRecordStore';
 import { useAuthStore } from '@stores/useAuthStore';
+import { useAssignmentStore } from '@stores/useAssignmentStore';
+import { useCompareCode } from '@hooks/useCompareCode';
 
 // 유사도에 따른 줄 배경색
 const getLineStyleBySimilarity = (similar: string[]): string => {
@@ -99,11 +101,65 @@ const ComparePage: React.FC = () => {
   const { files, selectedFileA, selectedFileB, setSelectedFiles } =
     useSelectedFileStore();
   const { isLoggedIn } = useAuthStore();
+  const { assignmentId, week } = useAssignmentStore();
 
+  // 선택 준비 여부 플래그
+  const selectedReady = Boolean(selectedFileA && selectedFileB);
+
+  // 훅은 무조건 호출 (빈값은 훅 내부 enabled 가드로 막음)
+  const {
+    data: compareData,
+    isLoading: isCompareLoading,
+    isError: isCompareError,
+  } = useCompareCode({
+    assignmentId: assignmentId ?? 0,
+    week: week ?? 0,
+    studentFromId: selectedFileA?.id ?? '',
+    studentToId: selectedFileB?.id ?? '',
+  });
+
+  // API 데이터를 스토어 형태로 합성 (선택 준비 + 데이터 도착 시)
+  useEffect(() => {
+    if (!selectedReady || !compareData) return;
+
+    const makeSimilarMap = (
+      lines: number[],
+      otherName: string
+    ): Record<number, string[]> => {
+      const map: Record<number, string[]> = {};
+      for (const n of lines ?? []) {
+        if (!Number.isFinite(n)) continue;
+        map[n] = [otherName];
+      }
+      return map;
+    };
+
+    const a = compareData.student1;
+    const b = compareData.student2;
+
+    const fileA = {
+      id: a.id,
+      label: `${a.name} (${a.fileName})`,
+      submittedAt: a.submissionTime,
+      content: a.code.code,
+      similarMap: makeSimilarMap(a.code.lines, b.name),
+    };
+
+    const fileB = {
+      id: b.id,
+      label: `${b.name} (${b.fileName})`,
+      submittedAt: b.submissionTime,
+      content: b.code.code,
+      similarMap: makeSimilarMap(b.code.lines, a.name),
+    };
+
+    setSelectedFiles(fileA, fileB);
+  }, [selectedReady, compareData, setSelectedFiles]);
+
+  // 저장본에서 진입 시 복원
   const fromSaved = (location.state as PairState | undefined)?.fromSaved;
   const recordId = (location.state as PairState | undefined)?.recordId;
 
-  // 저장본에서 진입 시 선택 복원
   useEffect(() => {
     if (fromSaved && recordId != null) {
       useSavedRecordStore.getState().selectRecordById(String(recordId));
@@ -114,7 +170,22 @@ const ComparePage: React.FC = () => {
     }
   }, [fromSaved, recordId, setSelectedFiles]);
 
-  if (!selectedFileA || !selectedFileB) {
+  const handleSave = () => {
+    if (!isLoggedIn) {
+      navigate('/login', { state: { from: 'result' } });
+    } else {
+      navigate('/decision', {
+        state: {
+          fileA: selectedFileA!,
+          fileB: selectedFileB!,
+          similarity: 0.95, // TODO: 실제 유사도로 교체
+        },
+      });
+    }
+  };
+
+  // UI 분기만 렌더 단계에서
+  if (!selectedReady) {
     return (
       <Layout>
         <div className="px-8 py-10">
@@ -131,21 +202,36 @@ const ComparePage: React.FC = () => {
     );
   }
 
-  const handleSave = () => {
-    if (!isLoggedIn) {
-      navigate('/login', { state: { from: 'result' } });
-    } else {
-      navigate('/decision', {
-        state: {
-          fileA: selectedFileA,
-          fileB: selectedFileB,
-          similarity: 0.95, // TODO: 실제 유사도로 교체
-        },
-      });
-    }
-  };
+  if (isCompareLoading) {
+    return (
+      <Layout>
+        <div className="max-w-7xl mx-auto px-8 py-10">
+          <Text variant="body" color="muted">
+            코드 비교 데이터를 불러오는 중...
+          </Text>
+        </div>
+      </Layout>
+    );
+  }
 
-  const fileLabels = [selectedFileA.label, selectedFileB.label];
+  if (isCompareError) {
+    return (
+      <Layout>
+        <div className="max-w-7xl mx-auto px-8 py-10 space-y-4">
+          <Text variant="body" color="muted">
+            코드 비교 데이터 로딩에 실패했어요.
+          </Text>
+          <Button
+            text="뒤로가기"
+            variant="secondary"
+            onClick={() => navigate(-1)}
+          />
+        </div>
+      </Layout>
+    );
+  }
+
+  const fileLabels = [selectedFileA!.label, selectedFileB!.label];
 
   return (
     <Layout>
@@ -164,7 +250,7 @@ const ComparePage: React.FC = () => {
 
         {/* 제목 */}
         <Text variant="heading" weight="bold" className="text-3xl text-black">
-          {selectedFileA.label} 와 {selectedFileB.label}의 코드 비교
+          {selectedFileA!.label} 와 {selectedFileB!.label}의 코드 비교
         </Text>
 
         {/* 파일 선택 */}
@@ -176,20 +262,20 @@ const ComparePage: React.FC = () => {
               .map((f) => ({ label: f.label, value: f.id }));
 
             return (
-              <div key={file.id}>
+              <div key={file!.id}>
                 <Select
                   options={options}
-                  value={file.id}
+                  value={file!.id}
                   onChange={(val) => {
                     if (val === other?.id) return;
                     const newFile = files.find((f) => f.id === val);
                     if (!newFile) return;
-                    if (idx === 0) setSelectedFiles(newFile, other);
-                    else setSelectedFiles(other, newFile);
+                    if (idx === 0) setSelectedFiles(newFile, other!);
+                    else setSelectedFiles(other!, newFile);
                   }}
                 />
                 <p className="mt-1 text-sm text-gray-600">
-                  제출 시간: {file.submittedAt}
+                  제출 시간: {file!.submittedAt}
                 </p>
               </div>
             );
@@ -199,18 +285,18 @@ const ComparePage: React.FC = () => {
         {/* 코드 비교 뷰어: 한 줄 = 두 칸 */}
         <div className="mt-6 overflow-hidden rounded border">
           <div className="grid grid-cols-2 border-b bg-gray-100 text-center font-bold text-lg">
-            <div className="py-3">{selectedFileA.label}</div>
-            <div className="py-3">{selectedFileB.label}</div>
+            <div className="py-3">{selectedFileA!.label}</div>
+            <div className="py-3">{selectedFileB!.label}</div>
           </div>
 
-          {selectedFileA.content.map((lineA, idx) => (
+          {selectedFileA!.content.map((lineA, idx) => (
             <CompareLineRow
               key={idx}
               idx={idx}
               lineA={lineA}
-              lineB={selectedFileB.content[idx] || ''}
-              similarA={selectedFileA.similarMap[idx + 1] || []}
-              similarB={selectedFileB.similarMap[idx + 1] || []}
+              lineB={selectedFileB!.content[idx] || ''}
+              similarA={selectedFileA!.similarMap[idx + 1] || []}
+              similarB={selectedFileB!.similarMap[idx + 1] || []}
               fileLabels={fileLabels}
             />
           ))}

--- a/src/features/Compare/ComparePage.tsx
+++ b/src/features/Compare/ComparePage.tsx
@@ -176,9 +176,18 @@ const ComparePage: React.FC = () => {
     } else {
       navigate('/decision', {
         state: {
-          fileA: selectedFileA!,
-          fileB: selectedFileB!,
-          similarity: 0.95, // TODO: 실제 유사도로 교체
+          fileA: {
+            id: selectedFileA!.id,
+            label: selectedFileA!.label,
+            submittedAt: selectedFileA!.submittedAt,
+          },
+          fileB: {
+            id: selectedFileB!.id,
+            label: selectedFileB!.label,
+            submittedAt: selectedFileB!.submittedAt,
+          },
+          studentFromId: selectedFileA!.id,
+          studentToId: selectedFileB!.id,
         },
       });
     }

--- a/src/features/Result/PlagiarismDecisionPage.tsx
+++ b/src/features/Result/PlagiarismDecisionPage.tsx
@@ -14,8 +14,8 @@ import { saveStudentPayload } from '@typings/result';
 type DecisionLocationState = {
   studentFromId?: string | number;
   studentToId?: string | number;
-  fileA?: { id: string; label: string; submittedAt: string };
-  fileB?: { id: string; label: string; submittedAt: string };
+  fileA?: { id: string; label: string; fileName?: string; submittedAt: string };
+  fileB?: { id: string; label: string; fileName?: string; submittedAt: string };
   similarity?: number;
 };
 
@@ -125,13 +125,19 @@ const PlagiarismDecisionPage: React.FC = () => {
   // judge, fileA, fileB 계산 이후에 아래 헬퍼로 payload 구성
   const toStudent = (
     who: 'student1' | 'student2',
-    fallback: { id: string; label: string; submittedAt: string }
+    fallback: {
+      id: string;
+      label: string;
+      submittedAt: string;
+      fileName?: string;
+    }
   ): saveStudentPayload => {
-    const j = judge[who]; // judge.student1 | judge.student2
+    const j = judge[who];
+    const parsedFromLabel = fallback.label.match(/\((.*?)\)\s*$/)?.[1] ?? '';
     return {
       id: j.id ?? fallback.id,
       name: j.name ?? fallback.label,
-      fileName: fallback.label || j.name || '', // 라벨을 파일명으로 사용
+      fileName: fallback.fileName ?? parsedFromLabel,
       submittedTime: j.submittedTime ?? fallback.submittedAt,
     };
   };

--- a/src/features/Result/PlagiarismDecisionPage.tsx
+++ b/src/features/Result/PlagiarismDecisionPage.tsx
@@ -143,12 +143,20 @@ const PlagiarismDecisionPage: React.FC = () => {
   };
 
   const handleDecision = (isPlagiarism: boolean) => {
+    const s1 = toStudent('student1', fileA);
+    const s2 = toStudent('student2', fileB);
+    if (!s1.fileName || !s2.fileName) {
+      alert(
+        '파일명을 확인할 수 없어 저장할 수 없습니다. 비교 페이지에서 다시 시도하거나 파일명이 포함된 라벨로 이동해주세요.'
+      );
+      return;
+    }
     const payload = {
       assignmentId: assignmentId!, // ready 체크 이미 통과했음
       week: week!,
       plagiarize: isPlagiarism,
-      student1: toStudent('student1', fileA),
-      student2: toStudent('student2', fileB),
+      student1: s1,
+      student2: s2,
     };
 
     saveMutation.mutate(payload, {

--- a/src/hooks/useCompareCode.ts
+++ b/src/hooks/useCompareCode.ts
@@ -1,12 +1,24 @@
 import { compareRequest, fetchCompare } from '@services/result';
 import { useQuery } from 'react-query';
-import { compareApiResponse } from 'types/result';
+import type { compareResponseData } from 'types/result';
 
-export const useCompareCode = (params: compareRequest, token: string) => {
-  return useQuery<compareApiResponse>({
-    queryKey: ['compareCode', params.student1, params.student2],
-    queryFn: () => fetchCompare(params, token),
-    enabled: !!token && !!params.student1 && !!params.student2,
+export const useCompareCode = (params: compareRequest) => {
+  const enabled =
+    !!params.assignmentId &&
+    !!params.week &&
+    !!params.studentFromId &&
+    !!params.studentToId;
+
+  return useQuery<compareResponseData>({
+    queryKey: [
+      'compareCode',
+      params.assignmentId,
+      params.week,
+      params.studentFromId,
+      params.studentToId,
+    ],
+    queryFn: () => fetchCompare(params),
+    enabled,
     staleTime: 1000 * 60 * 5,
   });
 };

--- a/src/hooks/usePlagiarismJudge.ts
+++ b/src/hooks/usePlagiarismJudge.ts
@@ -1,12 +1,24 @@
-import { compareRequest, fetchJudge } from '@services/result';
 import { useQuery } from 'react-query';
-import { judgeApiResponse } from 'types/result';
+import { fetchJudge, judgeRequest } from '@services/result';
+import type { judgeResponseData } from 'types/result';
 
-export const usePlagiarismJudge = (params: compareRequest, token: string) => {
-  return useQuery<judgeApiResponse>({
-    queryKey: ['plagiarismJudge', params.student1, params.student2],
-    queryFn: () => fetchJudge(params, token),
-    enabled: !!token && !!params.student1 && !!params.student2,
+export const usePlagiarismJudge = (params: judgeRequest) => {
+  const enabled =
+    !!params.assignmentId &&
+    !!params.week &&
+    !!params.studentFromId &&
+    !!params.studentToId;
+
+  return useQuery<judgeResponseData>({
+    queryKey: [
+      'judge',
+      params.assignmentId,
+      params.week,
+      params.studentFromId,
+      params.studentToId,
+    ],
+    queryFn: () => fetchJudge(params),
+    enabled,
     staleTime: 1000 * 60 * 5,
   });
 };

--- a/src/hooks/usePlagiarismSave.ts
+++ b/src/hooks/usePlagiarismSave.ts
@@ -1,0 +1,9 @@
+import { useMutation } from 'react-query';
+import { savePlagiarismResult } from '@services/result';
+import type { saveRequestPayload, saveApiResponse } from 'types/result';
+
+export const usePlagiarismSave = () => {
+  return useMutation<saveApiResponse, unknown, saveRequestPayload>((payload) =>
+    savePlagiarismResult(payload)
+  );
+};

--- a/src/hooks/useSimilarityGraph.ts
+++ b/src/hooks/useSimilarityGraph.ts
@@ -1,15 +1,12 @@
 import { fetchGraph, fetchGraphRequest } from '@services/result';
 import { useQuery } from 'react-query';
-import { graphApiResponse } from 'types/result';
+import type { graphMapped } from 'types/result';
 
-export const useSimilarityGraph = (
-  params: fetchGraphRequest,
-  token: string
-) => {
-  return useQuery<graphApiResponse>({
-    queryKey: ['similarityGraph', params.assignmentId, params.weekTitle],
-    queryFn: () => fetchGraph(params, token),
-    enabled: !!token && !!params.assignmentId && !!params.weekTitle,
+export const useSimilarityGraph = (params: fetchGraphRequest) => {
+  return useQuery<graphMapped>({
+    queryKey: ['similarityGraph', params.assignmentId, params.week],
+    queryFn: () => fetchGraph(params),
+    enabled: !!params.assignmentId && !!params.week,
     staleTime: 1000 * 60 * 5,
   });
 };

--- a/src/hooks/useSimilarityTopology.ts
+++ b/src/hooks/useSimilarityTopology.ts
@@ -2,14 +2,13 @@ import { fetchGraphRequest, fetchTopology } from '@services/result';
 import { useQuery } from 'react-query';
 import { topologyApiResponse } from 'types/result';
 
-export const useSimilarityTopology = (
-  params: fetchGraphRequest,
-  token: string
-) => {
+export const useSimilarityTopology = (params: fetchGraphRequest) => {
+  const enabled = !!params.assignmentId && !!params.week;
+
   return useQuery<topologyApiResponse>({
-    queryKey: ['similarityTopology', params.assignmentId, params.weekTitle],
-    queryFn: () => fetchTopology(params, token),
-    enabled: !!token && !!params.assignmentId && !!params.weekTitle,
+    queryKey: ['similarityTopology', params.assignmentId, params.week],
+    queryFn: () => fetchTopology(params),
+    enabled,
     staleTime: 1000 * 60 * 5,
   });
 };

--- a/src/mocks/compareMock.ts
+++ b/src/mocks/compareMock.ts
@@ -1,40 +1,20 @@
-import { compareApiResponse } from 'types/result';
+import { compareRawResponse } from 'types/result';
 
-export const compareMock: compareApiResponse = {
-  status: 200,
-  success: true,
-  message: {
-    student1: {
-      id: '21000000',
-      name: 'Student A',
-      fileName: 'file_name1.py',
-      submissionTime: '2025-03-29 17:05',
-      code: {
-        code: [
-          'int main() {',
-          '  int a = 10;',
-          '  int b = 20;',
-          '  return a + b;',
-          '}',
-        ],
-        lines: [2, 3],
-      },
-    },
-    student2: {
-      id: '21000001',
-      name: 'Student B',
-      fileName: 'file_name2.py',
-      submissionTime: '2025-03-29 19:05',
-      code: {
-        code: [
-          'int main() {',
-          '  int a = 10;',
-          '  int b = 20;',
-          '  return a + b;',
-          '}',
-        ],
-        lines: [2, 3],
-      },
-    },
+export const compareMock: compareRawResponse = {
+  student1: {
+    id: 'string',
+    name: 'string',
+    fileName: 'string',
+    submissionTime: 'string',
+    code: ['string'],
+    lines: [1073741824],
+  },
+  student2: {
+    id: 'string',
+    name: 'string',
+    fileName: 'string',
+    submissionTime: 'string',
+    code: ['string'],
+    lines: [1073741824],
   },
 };

--- a/src/mocks/graphMock.ts
+++ b/src/mocks/graphMock.ts
@@ -1,35 +1,32 @@
-import { graphApiResponse } from 'types/result';
+import { graphRawMessage } from 'types/result';
 
-export const graphMock: graphApiResponse = {
-  status: 200,
-  success: true,
-  message: {
-    nodes: [
-      { id: '21000000', label: 'Student A' },
-      { id: '21000001', label: 'Student B' },
-      { id: '21000002', label: 'Student C' },
+export const graphMock: graphRawMessage = {
+  nodes: [
+    {
+      id: 9007199254740991,
+      label: 'string',
+    },
+  ],
+  filterSummary: {
+    total: 1073741824,
+    aboveThreshold: 1073741824,
+    belowThreshold: 1073741824,
+    threshold: 0.1,
+  },
+  filterPairs: {
+    aboveThreshold: [
+      {
+        fromId: 9007199254740991,
+        toId: 9007199254740991,
+        similarity: 0.1,
+      },
     ],
-    filterSummary: {
-      total: 3,
-      aboveThreshold: 2,
-      belowThreshold: 1,
-      threshold: 0.7,
-    },
-    filteredPairs: {
-      aboveThreshold: [
-        {
-          from: '21000000',
-          to: '21000001',
-          similarity: 0.88,
-        },
-      ],
-      belowThreshold: [
-        {
-          from: '21000001',
-          to: '21000002',
-          similarity: 0.6,
-        },
-      ],
-    },
+    belowThreshold: [
+      {
+        fromId: 9007199254740991,
+        toId: 9007199254740991,
+        similarity: 0.1,
+      },
+    ],
   },
 };

--- a/src/mocks/saveMock.ts
+++ b/src/mocks/saveMock.ts
@@ -1,6 +1,3 @@
 import { saveApiResponse } from 'types/result';
 
-export const saveMock: saveApiResponse = {
-  status: 200,
-  success: true,
-};
+export const saveMock: saveApiResponse = 'string';

--- a/src/services/result.ts
+++ b/src/services/result.ts
@@ -221,6 +221,53 @@ export const fetchJudge = async ({
   }
 };
 
+/// 표절 판단 결과 저장
+export const savePlagiarismResult = async ({
+  assignmentId,
+  week,
+  plagiarize,
+  student1,
+  student2,
+}: import('types/result').saveRequestPayload): Promise<
+  import('types/result').saveApiResponse
+> => {
+  if (import.meta.env.VITE_USE_MOCK === 'true') {
+    await new Promise((r) => setTimeout(r, 300));
+    return 'OK(MOCK)';
+  }
+
+  const tryOnce = (fixedPath = false) => {
+    const base = fixedPath
+      ? '/api/result/assignments'
+      : '/api/result/assignmets';
+    const url = `${base}/${assignmentId}/save`;
+    return axiosInstance.post<import('types/result').saveApiResponse>(
+      url,
+      { plagiarize, student1, student2 },
+      {
+        params: { week },
+      }
+    );
+  };
+
+  try {
+    let resp: AxiosResponse<import('types/result').saveApiResponse>;
+    try {
+      resp = await tryOnce(false);
+    } catch (err: unknown) {
+      if (axios.isAxiosError(err) && err.response?.status === 404) {
+        resp = await tryOnce(true);
+      } else {
+        throw err;
+      }
+    }
+    return resp.data;
+  } catch (e) {
+    console.error('savePlagiarismResult error:', e);
+    throw e;
+  }
+};
+
 /// 결과 저장
 export interface saveStudent {
   id: string;

--- a/src/services/result.ts
+++ b/src/services/result.ts
@@ -22,12 +22,12 @@ export const fetchGraph = async ({
 
   try {
     const response = await axiosInstance.get<
-      import('types/result').graphApiResponse
+      import('types/result').graphRawMessage
     >(`/api/result/graph`, {
       params: { assignmentId, week },
     });
 
-    const raw = response.data.message;
+    const raw = response.data;
 
     // nodes 매핑 (id -> string)
     const nodes = raw.nodes.map((n) => ({

--- a/src/services/result.ts
+++ b/src/services/result.ts
@@ -64,10 +64,10 @@ export const fetchGraph = async ({
 };
 
 /// 유사도 네트워크 토폴로지
-export const fetchTopology = async (
-  { assignmentId, week }: fetchGraphRequest,
-  token: string
-): Promise<topologyApiResponse> => {
+export const fetchTopology = async ({
+  assignmentId,
+  week,
+}: fetchGraphRequest): Promise<topologyApiResponse> => {
   if (import.meta.env.VITE_USE_MOCK === 'true') {
     await new Promise((r) => setTimeout(r, 300));
     return topologyMock;
@@ -78,7 +78,6 @@ export const fetchTopology = async (
       `/api/result/topology`,
       {
         params: { assignmentId, week },
-        headers: { Authorization: `Bearer ${token}` },
       }
     );
     return response.data;

--- a/src/services/result.ts
+++ b/src/services/result.ts
@@ -114,9 +114,8 @@ export const fetchCompare = async ({
   if (import.meta.env.VITE_USE_MOCK === 'true') {
     await new Promise((r) => setTimeout(r, 300));
     const mock = (await import('@mocks/compareMock'))
-      .compareMock as import('types/result').compareApiResponse;
-    const raw =
-      mock.message as unknown as import('types/result').compareRawResponse;
+      .compareMock as import('types/result').compareRawResponse;
+    const raw = mock as unknown as import('types/result').compareRawResponse;
     return {
       student1: toCompareStudent(raw.student1),
       student2: toCompareStudent(raw.student2),
@@ -130,7 +129,7 @@ export const fetchCompare = async ({
       : '/api/result/assignmets';
     const url = `${base}/${assignmentId}/compare`;
     const resp = await axiosInstance.get<
-      import('types/result').compareApiResponse
+      import('types/result').compareRawResponse
     >(url, {
       params: { studentFromId, studentToId, week },
     });
@@ -138,7 +137,7 @@ export const fetchCompare = async ({
   };
 
   try {
-    let response: AxiosResponse<import('types/result').compareApiResponse>;
+    let response: AxiosResponse<import('types/result').compareRawResponse>;
 
     try {
       response = await tryOnce(false);
@@ -151,8 +150,7 @@ export const fetchCompare = async ({
       }
     }
 
-    const raw = response.data
-      .message as import('types/result').compareRawResponse;
+    const raw = response.data as import('types/result').compareRawResponse;
 
     return {
       student1: toCompareStudent(raw.student1),

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -1,15 +1,43 @@
 /// 유사도 분석 결과 그래프
 
-export interface graphNode {
-  id: string;
+export interface graphRawNode {
+  id: number;
   label: string;
 }
 
-export interface graphFilterSummary {
-  total: number; // 검사된 총 파일 갯수
-  aboveThreshold: number; // 유사도 임계선을 넘은 파일 갯수
-  belowThreshold: number; // 유사도 임계선에 못 미치는 파일 갯수
-  threshold: number; // 유사도 임계값
+export interface graphRawFilterSummary {
+  total: number;
+  aboveThreshold: number;
+  belowThreshold: number;
+  threshold: number;
+}
+
+export interface graphRawPairItem {
+  fromId: number;
+  toId: number;
+  similarity: number;
+}
+
+export interface graphRawFilterPairs {
+  aboveThreshold: graphRawPairItem[];
+  belowThreshold: graphRawPairItem[];
+}
+
+export interface graphRawMessage {
+  nodes: graphRawNode[];
+  filterSummary: graphRawFilterSummary;
+  filterPairs: graphRawFilterPairs;
+}
+
+export interface graphApiResponse {
+  status: number;
+  success: boolean;
+  message: graphRawMessage;
+}
+
+export interface graphNode {
+  id: string;
+  label: string;
 }
 
 export interface graphPairThreshold {
@@ -18,21 +46,20 @@ export interface graphPairThreshold {
   similarity: number;
 }
 
-export interface graphFilteredPair {
-  aboveThreshold: graphPairThreshold[];
-  belowThreshold: graphPairThreshold[];
+export interface graphFilterSummary {
+  total: number;
+  aboveThreshold: number;
+  belowThreshold: number;
+  threshold: number;
 }
 
-export interface graphResponseData {
+export interface graphMapped {
   nodes: graphNode[];
-  filterSummary: graphFilterSummary;
-  filteredPairs: graphFilteredPair;
-}
-
-export interface graphApiResponse {
-  status: number;
-  success: boolean;
-  message: graphResponseData;
+  summary: graphFilterSummary;
+  pairs: {
+    aboveThreshold: graphPairThreshold[];
+    belowThreshold: graphPairThreshold[];
+  };
 }
 
 /// 유사도 네트워크 토폴로지

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -105,6 +105,28 @@ export interface topologyApiResponse {
 
 /// 유사도 코드 비교
 
+// --- [compare: Raw from server] ---
+export interface compareRawStudent {
+  id: string;
+  name: string;
+  fileName: string;
+  submissionTime: string;
+  code: string[];
+  lines: number[];
+}
+
+export interface compareRawResponse {
+  student1: compareRawStudent;
+  student2: compareRawStudent;
+}
+
+export interface compareApiResponse {
+  status: number;
+  success: boolean;
+  message: compareRawResponse;
+}
+
+// --- [compare: Mapped for UI] ---
 export interface compareCode {
   code: string[];
   lines: number[];
@@ -121,12 +143,6 @@ export interface compareStudent {
 export interface compareResponseData {
   student1: compareStudent;
   student2: compareStudent;
-}
-
-export interface compareApiResponse {
-  status: number;
-  success: boolean;
-  message: compareResponseData;
 }
 
 /// 표절 판단

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -29,12 +29,6 @@ export interface graphRawMessage {
   filterPairs: graphRawFilterPairs;
 }
 
-export interface graphApiResponse {
-  status: number;
-  success: boolean;
-  message: graphRawMessage;
-}
-
 export interface graphNode {
   id: string;
   label: string;

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -167,7 +167,21 @@ export interface judgeApiResponse {
 
 /// 결과 저장
 
-export interface saveApiResponse {
-  status: number;
-  success: boolean;
+export type saveApiResponse = string;
+
+// 요청에 넣을 학생 타입
+export interface saveStudentPayload {
+  id: number | string;
+  name: string;
+  fileName: string;
+  submittedTime: string;
+}
+
+// 저장 요청 본문 + 쿼리 파라미터(week)와 path 파라미터(assignmentId)
+export interface saveRequestPayload {
+  assignmentId: number;
+  week: number;
+  plagiarize: boolean;
+  student1: saveStudentPayload;
+  student2: saveStudentPayload;
 }

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -120,12 +120,6 @@ export interface compareRawResponse {
   student2: compareRawStudent;
 }
 
-export interface compareApiResponse {
-  status: number;
-  success: boolean;
-  message: compareRawResponse;
-}
-
 // --- [compare: Mapped for UI] ---
 export interface compareCode {
   code: string[];


### PR DESCRIPTION
## 📌 PR 제목

## ✅ 변경 사항

- 1차 필터링 결과 조회 API 연동
- 코드 비교 API 연동
- 표절 판단 페이지 API 연동
- 표절 판단 결과 저장 API 연동
- 네트워크 토폴로지 API 연동


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 과제/주차 기반 비교·판정·저장 완전 연동(서버 판정·저장 및 서버 통계 반영)
  - 판정 결과 저장 UI 추가(저장 중/실패 배너, 버튼 비활성화 등)
  - 비교·결과·그래프 영역에 로딩/오류 안내 및 백 버튼/복구 흐름 제공

- Refactor
  - 로컬 데모에서 서버 중심 데이터 흐름으로 전환(그래프·토폴로지·비교 데이터 우선)
  - 비교·판정 화면에 준비성(ready) gating과 합성된 파일 데이터 사용으로 선택 분기 정리
  - API 기반 ID 매핑으로 그래프 상호작용·네비게이션 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->